### PR TITLE
Add annotaterb gem

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -1,0 +1,58 @@
+---
+:position: before
+:position_in_additional_file_patterns: before
+:position_in_class: before
+:position_in_factory: before
+:position_in_fixture: before
+:position_in_routes: before
+:position_in_serializer: before
+:position_in_test: before
+:classified_sort: true
+:exclude_controllers: true
+:exclude_factories: false
+:exclude_fixtures: false
+:exclude_helpers: true
+:exclude_scaffolds: true
+:exclude_serializers: false
+:exclude_sti_subclasses: false
+:exclude_tests: false
+:force: false
+:format_markdown: false
+:format_rdoc: false
+:format_yard: false
+:frozen: false
+:ignore_model_sub_dir: false
+:ignore_unknown_models: false
+:include_version: false
+:show_check_constraints: false
+:show_complete_foreign_keys: false
+:show_foreign_keys: true
+:show_indexes: true
+:simple_indexes: false
+:sort: false
+:timestamp: false
+:trace: false
+:with_comment: true
+:with_column_comments: true
+:with_table_comments: true
+:active_admin: false
+:command:
+:debug: false
+:hide_default_column_types: ''
+:hide_limit_column_types: ''
+:ignore_columns:
+:ignore_routes:
+:models: true
+:routes: false
+:skip_on_db_migrate: false
+:target_action: :do_annotations
+:wrapper:
+:wrapper_close:
+:wrapper_open:
+:classes_default_to_s: []
+:additional_file_patterns: []
+:model_dir:
+- app/models
+:require: []
+:root_dir:
+- ''

--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -38,8 +38,8 @@
 :active_admin: false
 :command:
 :debug: false
-:hide_default_column_types: ''
-:hide_limit_column_types: ''
+:hide_default_column_types: ""
+:hide_limit_column_types: ""
 :ignore_columns:
 :ignore_routes:
 :models: true
@@ -52,7 +52,7 @@
 :classes_default_to_s: []
 :additional_file_patterns: []
 :model_dir:
-- app/models
+  - app/models
 :require: []
 :root_dir:
-- ''
+  - ""

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# Annotates Rails/ActiveRecord Models, routes, fixtures, and others based on the
+# database schema.
+gem "annotaterb", "~> 4.14"
+
 # Easiest way to manage multi-environment settings in any ruby project or
 # framework.
 gem "config", "~> 5.5", ">= 5.5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    annotaterb (4.14.0)
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
@@ -350,6 +351,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  annotaterb (~> 4.14)
   bootsnap
   brakeman
   config (~> 5.5, >= 5.5.2)

--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end


### PR DESCRIPTION
Introduces the `annotaterb` gem to the project for annotating models, routes, fixtures, and other components based on the database schema. The most important changes include the addition of the `annotaterb` gem to the `Gemfile`, configuration settings in `.annotaterb.yml`, and a new rake task for `annotaterb`.

### References

* https://github.com/ctran/annotate_models
* https://github.com/drwl/annotaterb
* https://rubygems.org/gems/annotate
* https://rubygems.org/gems/annotaterb
* https://www.reddit.com/r/rails/comments/13keyfm/i_spent_the_past_3_months_working_on_a_fork_of/