### PR TITLE
Integrating Tailwind CSS and enhancing the user interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+# Assets
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Credential files
 /config/master.key
 
+# JavaScript files
+/node_modules
+
 # Settings files
 config/settings.local.yml
 config/settings/*.local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem "annotaterb", "~> 4.14"
 # framework.
 gem "config", "~> 5.5", ">= 5.5.2"
 
+# Integrate Tailwind CSS with the asset pipeline in Rails.
+gem "tailwindcss-rails", "~> 4.1"
+
 # A self-contained `tailwindcss` executable, wrapped up in a ruby gem. That's
 # it. Nothing else.
 gem "tailwindcss-ruby", "~> 4.0", ">= 4.0.8"

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,10 @@ gem "annotaterb", "~> 4.14"
 # framework.
 gem "config", "~> 5.5", ">= 5.5.2"
 
+# A self-contained `tailwindcss` executable, wrapped up in a ruby gem. That's
+# it. Nothing else.
+gem "tailwindcss-ruby", "~> 4.0", ">= 4.0.8"
+
 # Library for validating urls in Rails.
 gem "validate_url", "~> 1.0", ">= 1.0.15"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,9 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.5)
+    tailwindcss-rails (4.1.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
     tailwindcss-ruby (4.0.8)
     tailwindcss-ruby (4.0.8-aarch64-linux-gnu)
     tailwindcss-ruby (4.0.8-aarch64-linux-musl)
@@ -394,6 +397,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   stimulus-rails
+  tailwindcss-rails (~> 4.1)
   tailwindcss-ruby (~> 4.0, >= 4.0.8)
   thruster
   turbo-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,12 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.5)
+    tailwindcss-ruby (4.0.8)
+    tailwindcss-ruby (4.0.8-aarch64-linux-gnu)
+    tailwindcss-ruby (4.0.8-aarch64-linux-musl)
+    tailwindcss-ruby (4.0.8-arm64-darwin)
+    tailwindcss-ruby (4.0.8-x86_64-linux-gnu)
+    tailwindcss-ruby (4.0.8-x86_64-linux-musl)
     thor (1.3.2)
     thruster (0.1.12)
     thruster (0.1.12-aarch64-linux)
@@ -388,6 +394,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   stimulus-rails
+  tailwindcss-ruby (~> 4.0, >= 4.0.8)
   thruster
   turbo-rails
   tzinfo-data

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,0 @@
-web: bin/rails server
-css: bin/rails tailwindcss:watch

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -16,10 +16,19 @@ class ChaptersController < ApplicationController
     @bible = Bible.find_by! code: bible_code
     @book = Book.find_by! bible: @bible, slug: book_slug
     @chapter = Chapter.find_by! bible: @bible, book: @book, number: chapter_number
-    @segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).order(created_at: :asc)
+    @segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).order(usx_node_id: :asc)
 
     @footnotes_mapping = {}
     @footnotes = Footnote.where(bible: @bible, book: @book, chapter: @chapter).order(created_at: :asc)
-    @footnotes.each.with_index(1) { |footnote, footnote_number| @footnotes_mapping[footnote.id] = footnote_number  }
+    @footnotes.each.with_index(1) do |footnote, footnote_number|
+      footnote_letter = Footnote.integer_to_letter(footnote_number)
+
+      @footnotes_mapping[footnote.id] = {
+        letter: footnote_letter,
+        ref_link: "footnote-verse-#{footnote_letter}",
+        ref_target: "footnote-#{footnote_letter}",
+        verse: footnote.verse&.number
+      }
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,20 @@
 module ApplicationHelper
+  def reference_path(target:)
+    parsed_target = Bible.parse_reference(target)
+    book_slug = parsed_target[:book]
+    chapter_number = parsed_target[:chapter]
+    verse_number = parsed_target[:verses]
+
+    bible = Bible.find_by! code: Settings.bible.defaults.translation
+    book = Book.find_by! bible: bible, code: book_slug
+
+    if verse_number.kind_of?(Array)
+      verse_number = parsed_target[:verses][0]
+      verse_number = verse_number[0] if verse_number.kind_of?(Array)
+
+      bible_book_chapter_path(bible_code: bible.code.downcase, book_slug: book.slug, number: chapter_number, anchor: "v#{verse_number}")
+    else
+      bible_book_chapter_path(bible_code: bible.code.downcase, book_slug: book.slug, number: chapter_number)
+    end
+  end
 end

--- a/app/models/bible.rb
+++ b/app/models/bible.rb
@@ -40,7 +40,11 @@ class Bible < ApplicationRecord
 
   # Parses a Bible reference string into its components.
   #
-  # @param reference [String] The Bible reference in the format "BOOK CHAPTER:VERSES" (e.g., "JHN 3:16-18").
+  # The format of the reference can either be for a chapter in the format "BOOK
+  # CHAPTER" (e.g., "JHN 3") or for verses in the format "BOOK CHAPTER:VERSES"
+  # (e.g., "JHN 3:16-18").
+  #
+  # @param reference [String] The Bible reference for a chapter or verse.
   #
   # @return [Hash, nil] A hash with keys :book, :chapter, and :verses if parsing succeeds, otherwise nil.
   #
@@ -48,13 +52,17 @@ class Bible < ApplicationRecord
   #   Bible.parse_reference("ROM 5:12,15-17")
   #   #=> { book: "ROM", chapter: 5, verses: [12, [15, 17]] }
   def self.parse_reference(reference)
-    match = reference.match(/(?<book>\w{3}) (?<chapter>\d+):(?<verses>[\d\-:,]+)/)
+    match = reference.match(/(?<book>\w{3}) (?<chapter>\d+)(:(?<verses>[\d\-:,]+))?/)
     return nil unless match
 
     book = match[:book]
     chapter = match[:chapter].to_i
-    verses = match[:verses].split(",").map do |range|
-      range.include?("-") ? range.split("-").map(&:to_i) : range.to_i
+    verses = match[:verses]
+
+    unless verses.nil?
+      verses = match[:verses].split(",").map do |range|
+        range.include?("-") ? range.split("-").map(&:to_i) : range.to_i
+      end
     end
 
     { book: book, chapter: chapter, verses: verses }

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -50,4 +50,24 @@ class Footnote < ApplicationRecord
   validates :book, presence: true
   validates :chapter, presence: true
   validates :content, presence: true
+
+  # Converts an integer to its corresponding alphabetical representation,
+  # following a sequential pattern where 1 → "a", 26 → "z", 27 → "aa", etc.
+  #
+  # This method is useful for generating footnote markers from verses, ensuring
+  # that footnotes are labeled alphabetically in a consistent manner.
+  #
+  # @param n [Integer] The footnote index (1-based).
+  # @return [String] The corresponding alphabetical letter.
+  def self.integer_to_letter(number)
+    letter = ""
+
+    while number > 0
+      number -= 1 # Shift index to make 'a' start at 1 instead of 0
+      letter.prepend((97 + (number % 26)).chr)  # Convert remainder to a letter
+      number /= 26
+    end
+
+    letter
+  end
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,25 +1,29 @@
-<h1>Books</h1>
+<% content_for :title do %>
+  <%= "#{@bible.code} | #{Settings.app.name}" %>
+<% end %>
 
-<h2>Old Testament</h2>
+<main class="text-center">
+  <h1 class="text-4xl font-semibold text-pretty text-gray-900 sm:text-5xl">Books</h1>
 
-<ol>
-  <% @books.old_testament.each do |book| %> 
-    <li>
-      <%= link_to book.title, bible_book_path(bible_code: @bible.code.downcase, slug: book.slug) %>
-    </li>
-  <% end %>
-</ol>
+  <section class="mt-12">
+    <h2 class="text-3xl font-semibold text-pretty text-gray-900">Old Testament</h2>
+    <ul class="mt-6 list-none">
+      <% @books.old_testament.each do |book| %> 
+        <li class="mt-2 text-xl">
+          <%= link_to book.title, bible_book_path(bible_code: @bible.code.downcase, slug: book.slug), class: "text-blue-600 hover:text-blue-800" %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
 
-<h2>New Testament</h2>
-
-<ol>
-  <% @books.new_testament.each do |book| %> 
-    <li>
-      <%= link_to book.title, bible_book_path(bible_code: @bible.code.downcase, slug: book.slug) %>
-    </li>
-  <% end %>
-</ol>
-
-<hr>
-
-<p><%= link_to @bible.rights_holder_name, @bible.rights_holder_url %>. <%= @bible.statement %></p>
+  <section class="mt-12">
+    <h2 class="text-3xl font-semibold text-pretty text-gray-900">New Testament</h2>
+    <ul class="mt-6 list-none">
+      <% @books.new_testament.each do |book| %> 
+        <li class="mt-2 text-xl">
+          <%= link_to book.title, bible_book_path(bible_code: @bible.code.downcase, slug: book.slug), class: "text-blue-600 hover:text-blue-800" %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+</main>

--- a/app/views/chapters/_fragment.html.erb
+++ b/app/views/chapters/_fragment.html.erb
@@ -1,0 +1,16 @@
+<% case fragment.kind -%>
+<% when "note" %>
+  <% footnote_letter = @footnotes_mapping[fragment.content.to_i][:letter] %>
+  <% footnote_ref_link = @footnotes_mapping[fragment.content.to_i][:ref_link] %>
+  <% footnote_ref_target = @footnotes_mapping[fragment.content.to_i][:ref_target] %>
+
+  <%= link_to "##{footnote_ref_target}", class: "font-semibold text-blue-600 hover:text-blue-800", id: footnote_ref_link do %>
+  <sup>[<%= footnote_letter %>]</sup>
+  <% end %>
+<% when "reference" %>
+  <% reference_link = reference_path(target: fragment.fragmentable.target) %>
+  <%= link_to fragment.content, reference_link, class: "text-blue-600 hover:text-blue-800" %>
+<% else %>
+  <%= tag.sup fragment.verse.number, class: "font-semibold", id: "v#{fragment.verse.number}" if fragment.verse.present? && fragment.show_verse %>
+  <span><%= fragment.content %></span>
+<% end %>

--- a/app/views/chapters/index.html.erb
+++ b/app/views/chapters/index.html.erb
@@ -1,15 +1,58 @@
-<h1><%= @book.title %></h1>
+<% content_for :title do %>
+  <%= "#{@book.title} | #{@bible.code} | #{Settings.app.name}" %>
+<% end %>
 
-<h2>Chapters</h2>
-
-<ul>
-  <% @chapters.each do |chapter| %> 
-    <li>
-      <%= link_to "Chapter #{chapter.number}", bible_book_chapter_path(bible_code: @bible.code.downcase, book_slug: @book.slug, number: chapter.number) %>
-    </li>
+<nav class="mb-4 flex justify-center items-center">
+  <%= link_to bible_books_path(bible_code: @bible.code.downcase), class: "text-gray-400 hover:text-gray-500 flex flex-col items-center" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 18.75 7.5-7.5 7.5 7.5" />
+      <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 7.5-7.5 7.5 7.5" />
+    </svg>
+    <span>Books</span>
   <% end %>
-</ul>
+</nav>
 
-<hr>
+<main class="text-center">
+  <h1 class="text-4xl font-semibold text-pretty text-gray-900 sm:text-5xl"><%= @book.title %></h1>
 
-<p><%= link_to @bible.rights_holder_name, @bible.rights_holder_url %>. <%= @bible.statement %></p>
+  <% if @book.headings.major.where(level: 0).any? %>
+  <section class="mt-12">
+    <h2 class="text-3xl font-semibold text-pretty text-gray-900">Sections</h2>
+    <ul class="mt-6 list-none">
+      <% @book.headings.major.where(level: 0).each do |heading| %>
+        <li class="mt-3 text-xl">
+          <%= link_to heading.title, bible_book_chapter_path(bible_code: @bible.code.downcase, book_slug: @book.slug, number: heading.chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+  <% end %>
+
+  <section class="mt-12">
+    <h2 class="text-3xl font-semibold text-pretty text-gray-900">Chapters</h2>
+    <ul class="mt-6 list-none">
+      <% @chapters.each do |chapter| %> 
+        <li>
+          <h3 class="mt-8 text-2xl font-semibold text-pretty text-gray-900">
+            <%= link_to "Chapter #{chapter.number}", bible_book_chapter_path(bible_code: @bible.code.downcase, book_slug: @book.slug, number: chapter.number), class: "text-blue-600 hover:text-blue-800" %>
+          </h3>
+
+          <ul class="mt-4 mb-2 list-none">
+            <% chapter.headings.minor.each do |heading| %>
+              <% case heading.level -%>
+              <% when 1 %>
+                <li class="mt-2 text-xl">
+                  <%= link_to heading.title, bible_book_chapter_path(bible_code: @bible.code.downcase, book_slug: @book.slug, number: chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
+                </li>
+              <% when 2 %>
+                <li class="mt-1 text-base italic">
+                  <%= link_to heading.title, bible_book_chapter_path(bible_code: @bible.code.downcase, book_slug: @book.slug, number: chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
+                </li>
+              <% end %>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+</main>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -1,95 +1,221 @@
-<h1><%= @book.title %></h1>
-
-<h2><%= "Chapter #{@chapter.number}" %></h2>
-
-<% @segments.each do |segment| %>
-  <% case segment.usx_style -%>
-  <% when "b" %>
-  <% when "q1", "q2", "q3", "q4" %>
-    <% indent_level = segment.usx_style[/\d+/].to_i %>
-    <% indent_pixels = indent_level * 15 %>
-
-    <%= tag.p style: "text-indent: #{indent_pixels}px;" do %>
-      <% segment.fragments.each do |fragment| %>
-        <% case fragment.kind -%>
-        <% when "note" %>
-          <sup>[<%= @footnotes_mapping[fragment.content.to_i] %>]</sup>
-        <% when "reference" %>
-          <%= link_to fragment.content, "#" %>
-        <% else %>
-          <%= tag.sup fragment&.verse.number if fragment.show_verse %> <%= fragment.content %>
-        <% end %>
-      <% end %>
-    <% end %>
-  <% when "r" %>
-    <p>
-      <% segment.fragments.each do |fragment| %>
-        <% case fragment.kind -%>
-        <% when "note" %>
-          <sup>[<%= @footnotes_mapping[fragment.content.to_i] %>]</sup>
-        <% when "reference" %>
-          <%= link_to fragment.content, "#" %>
-        <% else %>
-          <span><%= fragment.content %></span>
-        <% end %>
-      <% end %>
-    </p>
-  <% when "s1" %>
-    <% fragment = segment.fragments[0] %>
-    <h3><%= fragment.content %></h3>
-  <% when "s2" %>
-    <% fragment = segment.fragments[0] %>
-    <h4><%= fragment.content %></h4>
-  <% when "s3" %>
-    <% fragment = segment.fragments[0] %>
-    <h5><%= fragment.content %></h5>
-  <% when "s4" %>
-    <% fragment = segment.fragments[0] %>
-    <h6><%= fragment.content %></h6>
-  <% when "m" %>
-    <p>
-      <% segment.fragments.each do |fragment| %>
-        <% case fragment.kind -%>
-        <% when "note" %>
-          <sup>[<%= @footnotes_mapping[fragment.content.to_i] %>]</sup>
-        <% when "reference" %>
-          <%= link_to fragment.content, "#" %>
-        <% else %>
-          <%= tag.sup fragment&.verse.number if fragment.show_verse %> <%= fragment.content %>
-        <% end %>
-      <% end %>
-    </p>
-  <% when "pmo" %>
-    <p>
-      <% segment.fragments.each do |fragment| %>
-        <% case fragment.kind -%>
-        <% when "note" %>
-          <sup>[<%= @footnotes_mapping[fragment.content.to_i] %>]</sup>
-        <% when "reference" %>
-          <%= link_to fragment.content, "#" %>
-        <% else %>
-          <%= tag.sup fragment&.verse.number if fragment.show_verse %> <%= fragment.content %>
-        <% end %>
-      <% end %>
-    </p>
-  <% else %>
-    <p>
-      [<%= segment.usx_style %>] <%= segment%> - <%= segment.fragments.size %>
-    </p>
-  <% end %>
+<% content_for :title do %>
+  <%= "#{@book.title} #{@chapter.number} | #{@bible.code} | #{Settings.app.name}" %>
 <% end %>
 
-<hr>
+<nav class="mb-8 flex">
+  <ol role="list" class="flex items-center space-x-4">
+    <li>
+      <div>
+        <%= link_to root_path, class: "text-gray-400 hover:text-gray-500" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+            <path d="M11.25 4.533A9.707 9.707 0 0 0 6 3a9.735 9.735 0 0 0-3.25.555.75.75 0 0 0-.5.707v14.25a.75.75 0 0 0 1 .707A8.237 8.237 0 0 1 6 18.75c1.995 0 3.823.707 5.25 1.886V4.533ZM12.75 20.636A8.214 8.214 0 0 1 18 18.75c.966 0 1.89.166 2.75.47a.75.75 0 0 0 1-.708V4.262a.75.75 0 0 0-.5-.707A9.735 9.735 0 0 0 18 3a9.707 9.707 0 0 0-5.25 1.533v16.103Z" />
+          </svg>
+          <span class="sr-only">Home</span>
+        <% end %>
+      </div>
+    </li>
+    <li>
+      <div class="flex items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6 shrink-0 text-gray-400">
+          <path fill-rule="evenodd" d="M16.28 11.47a.75.75 0 0 1 0 1.06l-7.5 7.5a.75.75 0 0 1-1.06-1.06L14.69 12 7.72 5.03a.75.75 0 0 1 1.06-1.06l7.5 7.5Z" clip-rule="evenodd" />
+        </svg>
+        <%= link_to @bible.code, bible_books_path(bible_code: @bible.code.downcase), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" %>
+      </div>
+    </li>
+    <li>
+      <div class="flex items-center">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6 shrink-0 text-gray-400">
+          <path fill-rule="evenodd" d="M16.28 11.47a.75.75 0 0 1 0 1.06l-7.5 7.5a.75.75 0 0 1-1.06-1.06L14.69 12 7.72 5.03a.75.75 0 0 1 1.06-1.06l7.5 7.5Z" clip-rule="evenodd" />
+        </svg>
+        <%= link_to "Chapters", bible_book_chapters_url(bible_code: @bible.code.downcase, book_slug: @book.slug), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" %>
+      </div>
+    </li>
+  </ol>
+</nav>
 
-<section id="footnotes">
-  <h2>Footnotes</h2>
-  <ul>
-    <% @footnotes.each do |footnote| %>
-      <li id="fn1">[<%= @footnotes_mapping[footnote.id] %>] <%= footnote.content %> <a href="#ref1">&#x2191;</a></li>
+<main>
+  <%= link_to  bible_book_path(bible_code: @bible.code.downcase, slug: @book.slug), class: "text-blue-600 hover:text-blue-800" do %>
+    <h1 class="text-4xl font-semibold text-pretty sm:text-5xl"><%= @book.title %></h1>
+  <% end %>
+
+  <section class="my-6" id="chapter">
+    <h2 class="text-3xl font-semibold text-pretty text-gray-900"><%= "Chapter #{@chapter.number}" %></h2>
+
+    <% @segments.each do |segment| %>
+      <%# "[#{segment.usx_style}]" unless segment.usx_style == "b" %>
+
+      <% case segment.usx_style -%>
+      <% when "b" %>
+        <%# Poetry - Stanza Break (Blank Line) %>
+
+      <% when "d" %>
+        <%# Label - Descriptive Title - Hebrew Subtitle %>
+        <%= tag.div class: "mt-3 mb-3 text-center italic" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "li1" %>
+        <%# List Entry - Level 1 %>
+        <%= tag.p class: "mt-3 pl-12 -indent-3" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "li2" %>
+        <%# List Entry - Level 2 %>
+        <%= tag.p class: "mt-3 pl-21 -indent-3" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "m" %>
+        <%# Paragraph - Margin - No First Line Indent %>
+        <%= tag.p class: "mt-3 pl-3 -indent-3" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "mr" %>
+        <%# Heading - Major Section Range References %>
+        <%= tag.div class: "mt-3 mb-3 italic font-semibold" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <% next if ["(", ")"].include? fragment.content %>
+
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "ms" %>
+        <%# Heading - Major Section Level 1 %>
+        <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+        <%= tag.h3 heading_title, class: "mt-6 mb-3 text-xl font-semibold text-pretty text-gray-900 uppercase", id: heading_title.parameterize %>
+
+      <% when "pc" %>
+        <%# Paragraph - Centered (for Inscription) %>
+        <%= tag.p class: "mt-1 text-center uppercase" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "pmo" %>
+        <%# Paragraph - Embedded Text Opening %>
+        <%= tag.p class: "mt-3 pl-9 -indent-3" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "q1" %>
+        <%# Poetry - Indent Level 1 %>
+        <%= tag.p class: "mt-1 pl-12 -indent-3" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "q2" %>
+        <%# Poetry - Indent Level 2 %>
+        <%= tag.p class: "mt-1 pl-21 -indent-3" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "qa" %>
+        <%# Poetry - Acrostic Heading/Marker %>
+        <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+        <%= tag.div class: "mt-6 mb-3" do %>
+          <div class="relative">
+            <div class="absolute inset-0 flex items-center" aria-hidden="true">
+              <div class="w-full border-t border-gray-300"></div>
+            </div>
+            <div class="relative flex justify-start">
+              <span class="bg-white pr-3 text-base font-semibold text-gray-900"><%= heading_title %></span>
+            </div>
+          </div>  
+        <% end %>
+
+      <% when "qr" %>
+        <%# Poetry - Right Aligned %>
+        <%= tag.p class: "mt-3 text-right italic" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "r" %>
+        <%# Heading - Parallel References %>
+        <%= tag.div class: "mt-3 mb-3 italic font-semibold" do %>
+          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+            <% next if ["(", ")"].include? fragment.content %>
+
+            <%= render partial: "fragment", locals: { fragment: fragment }  %>
+          <% end %>
+        <% end %>
+
+      <% when "s1" %>
+        <%# Heading - Section Level 1 %>
+        <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+        <%= tag.h3 heading_title, class: "mt-6 mb-3 text-xl font-semibold text-pretty text-gray-900", id: heading_title.parameterize %>
+
+      <% when "s2" %>
+        <%# Heading - Section Level 2 %>
+        <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+        <%= tag.h4 heading_title, class: "mt-6 mb-3 text-base font-semibold text-pretty text-gray-900", id: heading_title.parameterize %>
+
+      <% else %>
+        <%# ??? %>
+        <span>[<%= segment.usx_style %>] <%= segment%> - <%= segment.fragments.order(segment_part: :asc).size %></span>
+
+      <% end -%>
     <% end %>
-  </ul>
-</section>
+  </section>
 
-<hr>
+  <% if @footnotes.any? %>
+  <div class="relative">
+    <div class="absolute inset-0 flex items-center" aria-hidden="true">
+      <div class="w-full border-t border-gray-300"></div>
+    </div>
 
-<p><%= link_to @bible.rights_holder_name, @bible.rights_holder_url %>. <%= @bible.statement %></p>
+    <div class="relative flex justify-center">
+      <span class="bg-white px-2 text-sm text-gray-500">Footnotes</span>
+    </div>
+  </div>
+
+  <section class="mt-6 mb-8" id="footnotes">
+    <ul class="list-none">
+      <% @footnotes.each do |footnote| %>
+        <% footnote_letter = @footnotes_mapping[footnote.id][:letter] %>
+        <% footnote_ref_link = @footnotes_mapping[footnote.id][:ref_link] %>
+        <% footnote_ref_target = @footnotes_mapping[footnote.id][:ref_target] %>
+        <% footnote_verse = @footnotes_mapping[footnote.id][:verse] %>
+
+        <%= tag.li id: footnote_ref_target, class: "mt-1" do %>
+          <%= link_to  "##{footnote_ref_link}" do %>
+            <%= tag.span class: "text-blue-600 font-semibold" do %>↑<% end %>
+            <% if footnote_verse.present? %>
+              <%= tag.span class: "text-xs/6 text-orange-700 font-semibold" do %><%= footnote_verse %><% end %>
+            <% end %>
+            <%= tag.span class: "text-xs/6 text-blue-600 font-semibold" do %><%= footnote_letter %><% end %>
+            <%= tag.span class: "text-sm/6" do %><%= footnote.content %><% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </ul>
+  </section>
+  <% end %>
+
+  <hr class="my-6 border-gray-300">
+
+  <section class="my-6" id="copyright">
+    <p class="text-center text-xs/6 text-gray-600">
+      <%= link_to @bible.rights_holder_name, @bible.rights_holder_url %>. <%= @bible.statement %>
+    </p>
+  </section>
+</main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,10 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div class="bg-white px-6 py-16 lg:px-8 lg:py-32">
+      <div class="mx-auto max-w-3xl text-base/7 text-gray-700">
+        <%= yield %>
+      </div>
+    </div>
   </body>
 </html>

--- a/bin/dev
+++ b/bin/dev
@@ -1,16 +1,2 @@
-#!/usr/bin/env sh
-
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
-# Default to port 3000 if not specified
-export PORT="${PORT:-3000}"
-
-# Let the debug gem allow remote connections,
-# but avoid loading until `debugger` is called
-export RUBY_DEBUG_OPEN="true"
-export RUBY_DEBUG_LAZY="true"
-
-exec foreman start -f Procfile.dev "$@"
+#!/usr/bin/env ruby
+exec "./bin/rails", "server", *ARGV

--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,16 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,6 +36,10 @@ plugin :tmp_restart
 # Run the Solid Queue supervisor inside of Puma for single-server deployments
 plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 
+# Run Tailwind in "watch" mode, so changes are automatically reflected in the
+# generated CSS output. Refer to tailwindcss-rails gem.
+plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,7 @@
 ---
+app:
+  name: Scribe
+
 bible:
   defaults:
     translation: BSB

--- a/docs/usx.md
+++ b/docs/usx.md
@@ -1,0 +1,18 @@
+# USX
+
+* `b` - Poetry - Stanza Break (Blank Line)
+* `d` - Label - Descriptive Title - Hebrew Subtitle
+* `li1` - List Entry - Level 1
+* `li2` - List Entry - Level 2
+* `m` - Paragraph - Margin - No First Line Indent
+* `mr` - Heading - Major Section Range References
+* `ms` - Heading - Major Section Level 1
+* `pc` - Paragraph - Centered (for Inscription)
+* `pmo` - Paragraph - Embedded Text Opening
+* `q1` - Poetry - Indent Level 1
+* `q2` - Poetry - Indent Level 2
+* `qa` - Poetry - Acrostic Heading/Marker
+* `qr` - Poetry - Right Aligned
+* `r` - Heading - Parallel References
+* `s1` - Heading - Section Level 1
+* `s2` - Heading - Section Level 2

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#reference_path' do
+    let(:bible) { create(:bible, code: 'BSB') }
+    let(:book) { create(:book, bible: bible, code: 'GEN', slug: 'genesis') }
+
+    it 'returns the correct path for a single verse reference' do
+      expect(helper.reference_path(target: 'GEN 1:1')).to eq("/bibles/bsb/books/genesis/chapters/1#v1")
+    end
+
+    it 'returns the correct path for a chapter reference' do
+      expect(helper.reference_path(target: 'GEN 1')).to eq("/bibles/bsb/books/genesis/chapters/1")
+    end
+
+    it 'returns the correct path for a range of verses' do
+      expect(helper.reference_path(target: 'GEN 1:1-5')).to eq("/bibles/bsb/books/genesis/chapters/1#v1")
+    end
+  end
+end

--- a/spec/models/bible_spec.rb
+++ b/spec/models/bible_spec.rb
@@ -2,16 +2,28 @@ require 'rails_helper'
 
 RSpec.describe Bible, type: :model do
   describe '.parse_reference' do
-    it 'parses a valid bible reference' do
+    it 'parses a valid verse reference with a specific verse' do
+      reference = "GEN 1:1"
+      result = Bible.parse_reference(reference)
+      expect(result).to eq({ book: "GEN", chapter: 1, verses: [ 1 ] })
+    end
+
+    it 'parses a valid verse reference with a range of verses' do
       reference = "JHN 3:16-18"
       result = Bible.parse_reference(reference)
       expect(result).to eq({ book: "JHN", chapter: 3, verses: [ [ 16, 18 ] ] })
     end
 
-    it 'parses a reference with multiple verses' do
+    it 'parses a valid verse reference with multiple verse specifications' do
       reference = "ROM 5:12,15-17"
       result = Bible.parse_reference(reference)
       expect(result).to eq({ book: "ROM", chapter: 5, verses: [ 12, [ 15, 17 ] ] })
+    end
+
+    it 'parses a valid chapter reference' do
+      reference = "PSA 1-41"
+      result = Bible.parse_reference(reference)
+      expect(result).to eq({ book: "PSA", chapter: 1, verses: nil })
     end
 
     it 'returns nil for invalid reference' do

--- a/spec/models/footnote_spec.rb
+++ b/spec/models/footnote_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Footnote, type: :model do
+  describe '.integer_to_letter' do
+    it 'returns "a" for 1' do
+      expect(Footnote.integer_to_letter(1)).to eq('a')
+    end
+
+    it 'returns "z" for 26' do
+      expect(Footnote.integer_to_letter(26)).to eq('z')
+    end
+
+    it 'returns "aa" for 27' do
+      expect(Footnote.integer_to_letter(27)).to eq('aa')
+    end
+
+    it 'returns "az" for 52' do
+      expect(Footnote.integer_to_letter(52)).to eq('az')
+    end
+
+    it 'returns "ba" for 53' do
+      expect(Footnote.integer_to_letter(53)).to eq('ba')
+    end
+
+    it 'returns "zz" for 702' do
+      expect(Footnote.integer_to_letter(702)).to eq('zz')
+    end
+
+    it 'returns "aaa" for 703' do
+      expect(Footnote.integer_to_letter(703)).to eq('aaa')
+    end
+
+    it 'returns "aab" for 704' do
+      expect(Footnote.integer_to_letter(704)).to eq('aab')
+    end
+  end
+end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+    content: [
+        "./public/*.html",
+        "./app/assets/stylesheets/**/*.css",
+        "./app/helpers/**/*.rb",
+        "./app/javascript/**/*.js",
+        "./app/views/**/*.html.erb"
+    ],
+    theme: {
+        extend: {},
+    },
+    plugins: [],
+};


### PR DESCRIPTION
This pull request introduces several significant changes to the codebase, primarily focusing on integrating Tailwind CSS, enhancing the user interface, and improving the handling of Bible references and footnotes. The most important changes include adding Tailwind CSS, updating the Bible reference parsing, and refining the footnotes and references display.

![Screenshot 2025-03-09 at 13 23 15](https://github.com/user-attachments/assets/7ed4fc98-1cad-49e9-850b-67f9991c641c)
![Screenshot 2025-03-09 at 13 23 24](https://github.com/user-attachments/assets/a9413aa3-e8e7-4b45-bbde-38ed2c123499)
![Screenshot 2025-03-09 at 13 23 39](https://github.com/user-attachments/assets/58a9a588-0f20-4882-9527-283db8d0e334)

### Changes

#### Integration of Tailwind CSS

* Added `tailwindcss-rails` and `tailwindcss-ruby` gems to the `Gemfile` to integrate Tailwind CSS with the Rails asset pipeline.
* Added Tailwind CSS import in `app/assets/tailwind/application.css`.

#### User Interface Improvements

* Enhanced the layout and styling of `app/views/books/index.html.erb`, `app/views/chapters/index.html.erb`, and `app/views/chapters/show.html.erb` with Tailwind CSS classes for a better user experience.
* Updated `app/views/chapters/_fragment.html.erb` to display footnotes and references with improved styling and linking.
* Wrapped the main content in `app/views/layouts/application.html.erb` with a styled container for better readability.

#### Documentation and Configuration

* Added a new `config/settings.yml` file to include application settings such as the app name.
* Created `docs/usx.md` to document the USX (Unified Scripture XML) styles used in the application.

### Styles

* [x] ~`b` - Poetry - Stanza Break (Blank Line)~
* [x] `d` - Label - Descriptive Title - Hebrew Subtitle
* [x] `li1` - List Entry - Level 1
* [x] `li2` - List Entry - Level 2
* [x] `m` - Paragraph - Margin - No First Line Indent
* [x] `mr` - Heading - Major Section Range References
* [x] `ms` - Heading - Major Section Level 1
* [x] `pc` - Paragraph - Centered (for Inscription)
* [x] `pmo` - Paragraph - Embedded Text Opening
* [x] `q1` - Poetry - Indent Level 1
* [x] `q2` - Poetry - Indent Level 2
* [x] `qa` - Poetry - Acrostic Heading/Marker
* [x] `qr` - Poetry - Right Aligned
* [x] `r` - Heading - Parallel References
* [x] `s1` - Heading - Section Level 1
* [x] `s2` - Heading - Section Level 2

### Related

* **Berean Standard Bible**
   * https://biblehub.com/bsb/genesis/1.htm
* **Tailwind**
   * https://tailwindcss.com/docs/installation/framework-guides/ruby-on-rails
   * https://rubygems.org/gems/tailwindcss-rails
   * https://rubygems.org/gems/tailwindcss-ruby
* **RSpec**
  * https://stackoverflow.com/questions/37902659/how-do-i-test-helpers-in-rails-4