### PR TITLE
Associate fragments with footnotes and references using a polymorphic association

### DIFF
--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -43,6 +43,7 @@ class Footnote < ApplicationRecord
   belongs_to :book
   belongs_to :chapter
   belongs_to :verse, optional: true
+  has_many :fragments, as: :fragmentable
 
   # Validations
   validates :bible, presence: true

--- a/app/models/fragment.rb
+++ b/app/models/fragment.rb
@@ -4,20 +4,22 @@
 #
 # ### Columns
 #
-# Name              | Type               | Attributes
-# ----------------- | ------------------ | ---------------------------
-# **`id`**          | `bigint`           | `not null, primary key`
-# **`content`**     | `text`             | `not null`
-# **`kind`**        | `string`           | `not null`
-# **`show_verse`**  | `boolean`          | `not null`
-# **`created_at`**  | `datetime`         | `not null`
-# **`updated_at`**  | `datetime`         | `not null`
-# **`bible_id`**    | `bigint`           | `not null`
-# **`book_id`**     | `bigint`           | `not null`
-# **`chapter_id`**  | `bigint`           | `not null`
-# **`heading_id`**  | `bigint`           | `not null`
-# **`segment_id`**  | `bigint`           | `not null`
-# **`verse_id`**    | `bigint`           |
+# Name                     | Type               | Attributes
+# ------------------------ | ------------------ | ---------------------------
+# **`id`**                 | `bigint`           | `not null, primary key`
+# **`content`**            | `text`             | `not null`
+# **`fragmentable_type`**  | `string`           |
+# **`kind`**               | `string`           | `not null`
+# **`show_verse`**         | `boolean`          | `not null`
+# **`created_at`**         | `datetime`         | `not null`
+# **`updated_at`**         | `datetime`         | `not null`
+# **`bible_id`**           | `bigint`           | `not null`
+# **`book_id`**            | `bigint`           | `not null`
+# **`chapter_id`**         | `bigint`           | `not null`
+# **`fragmentable_id`**    | `bigint`           |
+# **`heading_id`**         | `bigint`           | `not null`
+# **`segment_id`**         | `bigint`           | `not null`
+# **`verse_id`**           | `bigint`           |
 #
 # ### Indexes
 #
@@ -27,6 +29,9 @@
 #     * **`book_id`**
 # * `index_fragments_on_chapter_id`:
 #     * **`chapter_id`**
+# * `index_fragments_on_fragmentable`:
+#     * **`fragmentable_type`**
+#     * **`fragmentable_id`**
 # * `index_fragments_on_heading_id`:
 #     * **`heading_id`**
 # * `index_fragments_on_segment_id`:
@@ -54,6 +59,7 @@ class Fragment < ApplicationRecord
   belongs_to :bible
   belongs_to :book
   belongs_to :chapter
+  belongs_to :fragmentable, polymorphic: true, optional: true
   belongs_to :heading
   belongs_to :segment
   belongs_to :verse, optional: true

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -43,6 +43,7 @@ class Reference < ApplicationRecord
   belongs_to :book
   belongs_to :chapter
   belongs_to :heading, optional: true
+  has_many :fragments, as: :fragmentable
 
   # Validations
   validates :bible, presence: true

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -7,7 +7,7 @@
 # Name              | Type               | Attributes
 # ----------------- | ------------------ | ---------------------------
 # **`id`**          | `bigint`           | `not null, primary key`
-# **`style`**       | `string`           | `not null`
+# **`usx_style`**   | `string`           | `not null`
 # **`created_at`**  | `datetime`         | `not null`
 # **`updated_at`**  | `datetime`         | `not null`
 # **`bible_id`**    | `bigint`           | `not null`
@@ -50,7 +50,7 @@ class Segment < ApplicationRecord
   validates :book, presence: true
   validates :chapter, presence: true
   validates :heading, presence: true
-  validates :style, presence: true
+  validates :usx_style, presence: true
 
   # Constants
   HEADER_STYLES_INTRODUCTORY = [ "h", "toc2", "toc1", "mt1" ]

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -3,10 +3,10 @@
 <h2><%= "Chapter #{@chapter.number}" %></h2>
 
 <% @segments.each do |segment| %>
-  <% case segment.style -%>
+  <% case segment.usx_style -%>
   <% when "b" %>
   <% when "q1", "q2", "q3", "q4" %>
-    <% indent_level = segment.style[/\d+/].to_i %>
+    <% indent_level = segment.usx_style[/\d+/].to_i %>
     <% indent_pixels = indent_level * 15 %>
 
     <%= tag.p style: "text-indent: #{indent_pixels}px;" do %>
@@ -74,7 +74,7 @@
     </p>
   <% else %>
     <p>
-      [<%= segment.style %>] <%= segment%> - <%= segment.fragments.size %>
+      [<%= segment.usx_style %>] <%= segment%> - <%= segment.fragments.size %>
     </p>
   <% end %>
 <% end %>

--- a/db/migrate/20250209182506_create_segments.rb
+++ b/db/migrate/20250209182506_create_segments.rb
@@ -5,7 +5,7 @@ class CreateSegments < ActiveRecord::Migration[8.0]
       t.references :book, null: false, foreign_key: { on_delete: :restrict }
       t.references :chapter, null: false, foreign_key: { on_delete: :restrict }
       t.references :heading, null: false, foreign_key: { on_delete: :restrict }
-      t.string :style, null: false
+      t.string :usx_style, null: false
 
       t.timestamps
     end

--- a/db/migrate/20250209182507_create_fragments.rb
+++ b/db/migrate/20250209182507_create_fragments.rb
@@ -10,6 +10,7 @@ class CreateFragments < ActiveRecord::Migration[8.0]
       t.boolean :show_verse, null: false
       t.string :kind, null: false
       t.text :content, null: false
+      t.belongs_to :fragmentable, polymorphic: true, null: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -118,7 +118,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_210537) do
     t.bigint "book_id", null: false
     t.bigint "chapter_id", null: false
     t.bigint "heading_id", null: false
-    t.string "style", null: false
+    t.string "usx_style", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["bible_id"], name: "index_segments_on_bible_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,11 +73,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_210537) do
     t.boolean "show_verse", null: false
     t.string "kind", null: false
     t.text "content", null: false
+    t.string "fragmentable_type"
+    t.bigint "fragmentable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["bible_id"], name: "index_fragments_on_bible_id"
     t.index ["book_id"], name: "index_fragments_on_book_id"
     t.index ["chapter_id"], name: "index_fragments_on_chapter_id"
+    t.index ["fragmentable_type", "fragmentable_id"], name: "index_fragments_on_fragmentable"
     t.index ["heading_id"], name: "index_fragments_on_heading_id"
     t.index ["segment_id"], name: "index_fragments_on_segment_id"
     t.index ["verse_id"], name: "index_fragments_on_verse_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,7 +83,7 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
         Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter.number} Heading #{heading.level} (#{heading.title})"
       end
 
-      segment = Segment.create!(bible: bible, book: book, chapter: chapter, heading: heading, style: segment_style)
+      segment = Segment.create!(bible: bible, book: book, chapter: chapter, heading: heading, usx_style: segment_style)
       Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter&.number} Segment #{segment.id}"
 
       segment_node.children.each do |fragment_node|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,6 +89,7 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
       segment_node.children.each do |fragment_node|
         fragment_text = fragment_node.text.strip
         fragment_kind = nil
+        fragmentable = nil
 
         case fragment_node.node_type
         when Nokogiri::XML::Node::ELEMENT_NODE
@@ -99,11 +100,13 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
             fragment_kind = "reference"
             reference_target = fragment_node["loc"]
             reference = Reference.create!(bible: bible, book: book, chapter: chapter, heading: heading, target: reference_target)
+            fragmentable = reference
             Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter.number} Reference #{reference.id}"
           when "note"
             fragment_kind = "note"
             footnote_text = fragment_node.children.select { |note_child_node| note_child_node.node_name == "char" && note_child_node["style"] == "ft" }.first.text.strip
             footnote = Footnote.create!(bible: bible, book: book, chapter: chapter, verse: verse, content: footnote_text)
+            fragmentable = footnote
             fragment_text = "#{footnote.id}"
             Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter.number} Verse #{verse&.number} Footnote #{footnote.id}"
           when "verse"
@@ -124,7 +127,7 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
 
         next if fragment_text.empty?
 
-        fragment = Fragment.create!(bible: bible, book: book, segment: segment, chapter: chapter, heading: heading, verse: verse, kind: fragment_kind, show_verse: show_verse, content: fragment_text)
+        fragment = Fragment.create!(bible: bible, book: book, segment: segment, chapter: chapter, heading: heading, verse: verse, kind: fragment_kind, show_verse: show_verse, content: fragment_text, fragmentable: fragmentable)
         show_verse = false if fragment.show_verse
         Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter&.number} Segment #{segment.id} Fragment #{fragment.id} (#{fragment.content})"
       end


### PR DESCRIPTION
This pull request includes changes to add polymorphic associations for fragments and to rename a column in the `Segment` model. The most important changes include modifying the `Fragment` and `Segment` models, updating the migrations and schema, and adjusting the seed data accordingly.

### Changes

#### Polymorphic Associations for Fragments:

* Added `fragmentable_type` and `fragmentable_id` columns, and a polymorphic `belongs_to :fragmentable` association.
* Added a `has_many :fragments` association to make `Footnote` a fragmentable entity.
* Added a `has_many :fragments` association to make `Reference` a fragmentable entity.
* Updated migration to include polymorphic `fragmentable` references.
* Updated seed data to set the `fragmentable` association for fragments.

#### Renaming `style` to `usx_style` in `Segment`:

* Renamed the `style` column to `usx_style` and updated validations accordingly.
* Updated migration to rename `style` to `usx_style`.
* Updated schema to reflect the renaming of `style` to `usx_style`.
* Updated seed data to use `usx_style` instead of `style` when creating segments.