### PR TITLE
Link Segment and Verse models

### DIFF
--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -53,7 +53,7 @@ class Segment < ApplicationRecord
   validates :book, presence: true
   validates :chapter, presence: true
   validates :heading, presence: true
-  validates :usx_node_id, presence: true
+  validates :usx_node_id, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :usx_style, presence: true
 
   # Constants

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -45,6 +45,8 @@ class Segment < ApplicationRecord
   belongs_to :chapter
   belongs_to :heading
   has_many :fragments, dependent: :restrict_with_error
+  has_many :segment_verse_associations, dependent: :destroy
+  has_many :verses, through: :segment_verse_associations
 
   # Validations
   validates :bible, presence: true

--- a/app/models/segment_verse_association.rb
+++ b/app/models/segment_verse_association.rb
@@ -1,0 +1,9 @@
+class SegmentVerseAssociations < ApplicationRecord
+  # Associations
+  belongs_to :segment
+  belongs_to :verse
+
+  # Validations
+  validates :segment_id, presence: true
+  validates :verse_id, presence: true
+end

--- a/app/models/segment_verse_association.rb
+++ b/app/models/segment_verse_association.rb
@@ -1,4 +1,32 @@
-class SegmentVerseAssociations < ApplicationRecord
+# ## Schema Information
+#
+# Table name: `segment_verse_associations`
+#
+# ### Columns
+#
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`segment_id`**  | `bigint`           | `not null`
+# **`verse_id`**    | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_segment_verse_associations_on_segment_id`:
+#     * **`segment_id`**
+# * `index_segment_verse_associations_on_verse_id`:
+#     * **`verse_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`segment_id => segments.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`verse_id => verses.id`**
+#
+class SegmentVerseAssociation < ApplicationRecord
   # Associations
   belongs_to :segment
   belongs_to :verse

--- a/app/models/verse.rb
+++ b/app/models/verse.rb
@@ -44,6 +44,8 @@ class Verse < ApplicationRecord
   belongs_to :chapter
   has_many :footnotes, dependent: :restrict_with_error
   has_many :fragments, dependent: :restrict_with_error
+  has_many :segment_verse_associations, dependent: :destroy
+  has_many :segments, through: :segment_verse_associations
 
   # Validations
   validates :bible, presence: true

--- a/db/migrate/20250323090004_create_segment_verse_associations.rb
+++ b/db/migrate/20250323090004_create_segment_verse_associations.rb
@@ -1,0 +1,10 @@
+class CreateSegmentVerseAssociations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :segment_verse_associations do |t|
+      t.references :segment, null: false, foreign_key: { on_delete: :cascade }
+      t.references :verse, null: false, foreign_key: { on_delete: :cascade }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_19_210537) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_23_090004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -115,6 +115,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_210537) do
     t.index ["heading_id"], name: "index_references_on_heading_id"
   end
 
+  create_table "segment_verse_associations", force: :cascade do |t|
+    t.bigint "segment_id", null: false
+    t.bigint "verse_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["segment_id"], name: "index_segment_verse_associations_on_segment_id"
+    t.index ["verse_id"], name: "index_segment_verse_associations_on_verse_id"
+  end
+
   create_table "segments", force: :cascade do |t|
     t.bigint "bible_id", null: false
     t.bigint "book_id", null: false
@@ -163,6 +172,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_210537) do
   add_foreign_key "references", "books", on_delete: :restrict
   add_foreign_key "references", "chapters", on_delete: :restrict
   add_foreign_key "references", "headings", on_delete: :restrict
+  add_foreign_key "segment_verse_associations", "segments", on_delete: :cascade
+  add_foreign_key "segment_verse_associations", "verses", on_delete: :cascade
   add_foreign_key "segments", "bibles", on_delete: :restrict
   add_foreign_key "segments", "books", on_delete: :restrict
   add_foreign_key "segments", "chapters", on_delete: :restrict

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -119,6 +119,7 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
               show_verse = true
               verse_number = fragment_node["number"].to_i
               verse = Verse.create!(bible: bible, book: book, chapter: chapter, number: verse_number)
+              segment.verses << verse
               Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter.number} Verse #{verse&.number}"
             elsif fragment_node.key?("eid")
               verse = nil


### PR DESCRIPTION
This pull request introduces a new association between `Segment` and `Verse` models, along with the necessary database migrations and schema updates. The changes ensure that segments can be linked to multiple verses and vice versa.

Key changes include:

### Model Associations:
* Added `has_many :segment_verse_associations` and `has_many :verses, through: :segment_verse_associations` to the `Segment` model (`app/models/segment.rb`).
* Added `has_many :segment_verse_associations` and `has_many :segments, through: :segment_verse_associations` to the `Verse` model (`app/models/verse.rb`).

### New Model:
* Created a new `SegmentVerseAssociation` model to manage the many-to-many relationship between segments and verses (`app/models/segment_verse_association.rb`).

### Database Migrations:
* Added a migration to create the `segment_verse_associations` table with foreign keys and indexes (`db/migrate/20250323090004_create_segment_verse_associations.rb`).
* Updated the schema to reflect the new `segment_verse_associations` table and its foreign keys (`db/schema.rb`).

### Seed Data:
* Modified the seed file to associate segments with verses when creating new verses (`db/seeds.rb`).