### PR TITLE
Add ability to group segments into sections

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -16,7 +16,7 @@ class ChaptersController < ApplicationController
     @bible = Bible.find_by! code: bible_code
     @book = Book.find_by! bible: @bible, slug: book_slug
     @chapter = Chapter.find_by! bible: @bible, book: @book, number: chapter_number
-    @segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).order(usx_node_id: :asc)
+    @segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).where.not(usx_style: "b").order(usx_node_id: :asc)
 
     @footnotes_mapping = {}
     @footnotes = Footnote.where(bible: @bible, book: @book, chapter: @chapter).order(created_at: :asc)

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -16,7 +16,9 @@ class ChaptersController < ApplicationController
     @bible = Bible.find_by! code: bible_code
     @book = Book.find_by! bible: @bible, slug: book_slug
     @chapter = Chapter.find_by! bible: @bible, book: @book, number: chapter_number
-    @segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).where.not(usx_style: "b").order(usx_node_id: :asc)
+
+    segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).where.not(usx_style: "b").order(usx_node_id: :asc)
+    @sectioned_segments = Segment.group_in_sections(segments)
 
     @footnotes_mapping = {}
     @footnotes = Footnote.where(bible: @bible, book: @book, chapter: @chapter).order(created_at: :asc)

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -41,7 +41,9 @@
   <section class="my-6" id="chapter">
     <h2 class="text-3xl font-semibold text-pretty text-gray-900"><%= "Chapter #{@chapter.number}" %></h2>
 
-    <% @segments.each do |segment| %>
+    <% @sectioned_segments.each_with_index do |section_segments, section_index| %>
+      <%= tag.div id: "section-#{section_index}" do %>
+      <% section_segments.each do |segment| %>
       <%# "[#{segment.usx_style}]" unless segment.usx_style == "b" %>
 
       <% case segment.usx_style -%>
@@ -174,6 +176,8 @@
         <span>[<%= segment.usx_style %>] <%= segment%> - <%= segment.fragments.order(segment_part: :asc).size %></span>
 
       <% end -%>
+      <% end %>
+      <% end %>
     <% end %>
   </section>
 

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -43,140 +43,140 @@
 
     <% @sectioned_segments.each_with_index do |section_segments, section_index| %>
       <%= tag.div id: "section-#{section_index}" do %>
-      <% section_segments.each do |segment| %>
-      <%# "[#{segment.usx_style}, #{segment.verses.ids}]" unless segment.usx_style == "b" %>
+        <% section_segments.each do |segment| %>
+          <%# "[#{segment.usx_style}, #{segment.verses.ids}]" unless segment.usx_style == "b" %>
 
-      <% case segment.usx_style -%>
-      <% when "b" %>
-        <%# Poetry - Stanza Break (Blank Line) %>
+          <% case segment.usx_style -%>
+          <% when "b" %>
+            <%# Poetry - Stanza Break (Blank Line) %>
 
-      <% when "d" %>
-        <%# Label - Descriptive Title - Hebrew Subtitle %>
-        <%= tag.div class: "mt-3 mb-3 text-center italic" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
+          <% when "d" %>
+            <%# Label - Descriptive Title - Hebrew Subtitle %>
+            <%= tag.div class: "mt-3 mb-3 text-center italic" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "li1" %>
+            <%# List Entry - Level 1 %>
+            <%= tag.p class: "mt-3 pl-12 -indent-3" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "li2" %>
+            <%# List Entry - Level 2 %>
+            <%= tag.p class: "mt-3 pl-21 -indent-3" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "m" %>
+            <%# Paragraph - Margin - No First Line Indent %>
+            <%= tag.p class: "mt-3 pl-3 -indent-3" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "mr" %>
+            <%# Heading - Major Section Range References %>
+            <%= tag.div class: "mt-3 mb-3 italic font-semibold" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <% next if ["(", ")"].include? fragment.content %>
+
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "ms" %>
+            <%# Heading - Major Section Level 1 %>
+            <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+            <%= tag.h3 heading_title, class: "mt-6 mb-3 text-xl font-semibold text-pretty text-gray-900 uppercase", id: heading_title.parameterize %>
+
+          <% when "pc" %>
+            <%# Paragraph - Centered (for Inscription) %>
+            <%= tag.p class: "mt-1 text-center uppercase" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "pmo" %>
+            <%# Paragraph - Embedded Text Opening %>
+            <%= tag.p class: "mt-3 pl-9 -indent-3" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "q1" %>
+            <%# Poetry - Indent Level 1 %>
+            <%= tag.p class: "mt-1 pl-12 -indent-3" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "q2" %>
+            <%# Poetry - Indent Level 2 %>
+            <%= tag.p class: "mt-1 pl-21 -indent-3" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "qa" %>
+            <%# Poetry - Acrostic Heading/Marker %>
+            <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+            <%= tag.div class: "mt-6 mb-3" do %>
+              <div class="relative">
+                <div class="absolute inset-0 flex items-center" aria-hidden="true">
+                  <div class="w-full border-t border-gray-300"></div>
+                </div>
+                <div class="relative flex justify-start">
+                  <span class="bg-white pr-3 text-base font-semibold text-gray-900"><%= heading_title %></span>
+                </div>
+              </div>  
+            <% end %>
+
+          <% when "qr" %>
+            <%# Poetry - Right Aligned %>
+            <%= tag.p class: "mt-3 text-right italic" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "r" %>
+            <%# Heading - Parallel References %>
+            <%= tag.div class: "mt-3 mb-3 italic font-semibold" do %>
+              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+                <% next if ["(", ")"].include? fragment.content %>
+
+                <%= render partial: "fragment", locals: { fragment: fragment }  %>
+              <% end %>
+            <% end %>
+
+          <% when "s1" %>
+            <%# Heading - Section Level 1 %>
+            <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+            <%= tag.h3 heading_title, class: "mt-6 mb-3 text-xl font-semibold text-pretty text-gray-900", id: heading_title.parameterize %>
+
+          <% when "s2" %>
+            <%# Heading - Section Level 2 %>
+            <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+            <%= tag.h4 heading_title, class: "mt-6 mb-3 text-base font-semibold text-pretty text-gray-900", id: heading_title.parameterize %>
+
+          <% else %>
+            <%# ??? %>
+            <span>[<%= segment.usx_style %>] <%= segment%> - <%= segment.fragments.order(segment_part: :asc).size %></span>
+
+          <% end -%>
         <% end %>
-
-      <% when "li1" %>
-        <%# List Entry - Level 1 %>
-        <%= tag.p class: "mt-3 pl-12 -indent-3" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "li2" %>
-        <%# List Entry - Level 2 %>
-        <%= tag.p class: "mt-3 pl-21 -indent-3" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "m" %>
-        <%# Paragraph - Margin - No First Line Indent %>
-        <%= tag.p class: "mt-3 pl-3 -indent-3" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "mr" %>
-        <%# Heading - Major Section Range References %>
-        <%= tag.div class: "mt-3 mb-3 italic font-semibold" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <% next if ["(", ")"].include? fragment.content %>
-
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "ms" %>
-        <%# Heading - Major Section Level 1 %>
-        <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
-        <%= tag.h3 heading_title, class: "mt-6 mb-3 text-xl font-semibold text-pretty text-gray-900 uppercase", id: heading_title.parameterize %>
-
-      <% when "pc" %>
-        <%# Paragraph - Centered (for Inscription) %>
-        <%= tag.p class: "mt-1 text-center uppercase" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "pmo" %>
-        <%# Paragraph - Embedded Text Opening %>
-        <%= tag.p class: "mt-3 pl-9 -indent-3" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "q1" %>
-        <%# Poetry - Indent Level 1 %>
-        <%= tag.p class: "mt-1 pl-12 -indent-3" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "q2" %>
-        <%# Poetry - Indent Level 2 %>
-        <%= tag.p class: "mt-1 pl-21 -indent-3" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "qa" %>
-        <%# Poetry - Acrostic Heading/Marker %>
-        <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
-        <%= tag.div class: "mt-6 mb-3" do %>
-          <div class="relative">
-            <div class="absolute inset-0 flex items-center" aria-hidden="true">
-              <div class="w-full border-t border-gray-300"></div>
-            </div>
-            <div class="relative flex justify-start">
-              <span class="bg-white pr-3 text-base font-semibold text-gray-900"><%= heading_title %></span>
-            </div>
-          </div>  
-        <% end %>
-
-      <% when "qr" %>
-        <%# Poetry - Right Aligned %>
-        <%= tag.p class: "mt-3 text-right italic" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "r" %>
-        <%# Heading - Parallel References %>
-        <%= tag.div class: "mt-3 mb-3 italic font-semibold" do %>
-          <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
-            <% next if ["(", ")"].include? fragment.content %>
-
-            <%= render partial: "fragment", locals: { fragment: fragment }  %>
-          <% end %>
-        <% end %>
-
-      <% when "s1" %>
-        <%# Heading - Section Level 1 %>
-        <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
-        <%= tag.h3 heading_title, class: "mt-6 mb-3 text-xl font-semibold text-pretty text-gray-900", id: heading_title.parameterize %>
-
-      <% when "s2" %>
-        <%# Heading - Section Level 2 %>
-        <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
-        <%= tag.h4 heading_title, class: "mt-6 mb-3 text-base font-semibold text-pretty text-gray-900", id: heading_title.parameterize %>
-
-      <% else %>
-        <%# ??? %>
-        <span>[<%= segment.usx_style %>] <%= segment%> - <%= segment.fragments.order(segment_part: :asc).size %></span>
-
-      <% end -%>
-      <% end %>
       <% end %>
     <% end %>
   </section>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -44,7 +44,7 @@
     <% @sectioned_segments.each_with_index do |section_segments, section_index| %>
       <%= tag.div id: "section-#{section_index}" do %>
       <% section_segments.each do |segment| %>
-      <%# "[#{segment.usx_style}]" unless segment.usx_style == "b" %>
+      <%# "[#{segment.usx_style}, #{segment.verses.ids}]" unless segment.usx_style == "b" %>
 
       <% case segment.usx_style -%>
       <% when "b" %>

--- a/spec/models/segment_spec.rb
+++ b/spec/models/segment_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Segment, type: :model do
+  describe '.group_in_sections' do
+    it 'groups segments in sections'
+  end
+end


### PR DESCRIPTION
Improve the organisation and presentation of segments within chapters. The most important changes include modifying the `show` action in the `ChaptersController`, adding a new grouping method in the `Segment` model, updating the chapter view to display grouped segments, and adding a new (pending) test for the grouping method.

* **Segment Organisation:**
  * `app/controllers/chapters_controller.rb`: Modified the `show` action to exclude segments with `usx_style: "b"` and group the remaining segments into sections using the new `group_in_sections` method.
  * `app/models/segment.rb`: Added `CONTENT_STYLES` and `GROUPABLE_STYLES` constants and implemented the `group_in_sections` method to group segments into logically coherent sections based on their USX styles.
* **View Updates:**
  * `app/views/chapters/show.html.erb`: Updated the chapter view to iterate over `@sectioned_segments` and display each section, ensuring segments are grouped and presented according to their styles.
* **Testing:**
  * `spec/models/segment_spec.rb`: Added a new test file for the `Segment` model, including a placeholder test for the `group_in_sections` method.