### PR TITLE
Use position for ordering attribute consistently

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -17,7 +17,7 @@ class ChaptersController < ApplicationController
     @book = Book.find_by! bible: @bible, slug: book_slug
     @chapter = Chapter.find_by! bible: @bible, book: @book, number: chapter_number
 
-    segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).where.not(usx_style: "b").order(usx_node_id: :asc)
+    segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).where.not(usx_style: "b").order(usx_position: :asc)
     @sectioned_segments = Segment.group_in_sections(segments)
 
     @footnotes_mapping = {}

--- a/app/models/fragment.rb
+++ b/app/models/fragment.rb
@@ -10,7 +10,7 @@
 # **`content`**            | `text`             | `not null`
 # **`fragmentable_type`**  | `string`           |
 # **`kind`**               | `string`           | `not null`
-# **`segment_part`**       | `integer`          | `not null`
+# **`position`**           | `integer`          | `not null`
 # **`show_verse`**         | `boolean`          | `not null`
 # **`created_at`**         | `datetime`         | `not null`
 # **`updated_at`**         | `datetime`         | `not null`
@@ -72,7 +72,7 @@ class Fragment < ApplicationRecord
   validates :content, presence: true
   validates :heading, presence: true
   validates :kind, presence: true
-  validates :segment_part, presence: true
+  validates :position, presence: true
   validates :segment, presence: true
   validates :show_verse, inclusion: { in: [ true, false ] }
 

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -4,17 +4,17 @@
 #
 # ### Columns
 #
-# Name               | Type               | Attributes
-# ------------------ | ------------------ | ---------------------------
-# **`id`**           | `bigint`           | `not null, primary key`
-# **`usx_style`**    | `string`           | `not null`
-# **`created_at`**   | `datetime`         | `not null`
-# **`updated_at`**   | `datetime`         | `not null`
-# **`bible_id`**     | `bigint`           | `not null`
-# **`book_id`**      | `bigint`           | `not null`
-# **`chapter_id`**   | `bigint`           | `not null`
-# **`heading_id`**   | `bigint`           | `not null`
-# **`usx_node_id`**  | `integer`          | `not null`
+# Name                | Type               | Attributes
+# ------------------- | ------------------ | ---------------------------
+# **`id`**            | `bigint`           | `not null, primary key`
+# **`usx_position`**  | `integer`          | `not null`
+# **`usx_style`**     | `string`           | `not null`
+# **`created_at`**    | `datetime`         | `not null`
+# **`updated_at`**    | `datetime`         | `not null`
+# **`bible_id`**      | `bigint`           | `not null`
+# **`book_id`**       | `bigint`           | `not null`
+# **`chapter_id`**    | `bigint`           | `not null`
+# **`heading_id`**    | `bigint`           | `not null`
 #
 # ### Indexes
 #
@@ -53,7 +53,7 @@ class Segment < ApplicationRecord
   validates :book, presence: true
   validates :chapter, presence: true
   validates :heading, presence: true
-  validates :usx_node_id, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :usx_position, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :usx_style, presence: true
 
   # Constants
@@ -83,7 +83,7 @@ class Segment < ApplicationRecord
   # @return [Array<Array<Segment>>] an array of arrays, where each inner array
   # represents a grouped section of segments.
   #
-  # @example segments = Segment.where(bible: @bible, book: @book, chapter: @chapter) .where.not(usx_style: "b") .order(usx_node_id: :asc)
+  # @example segments = Segment.where(bible: @bible, book: @book, chapter: @chapter) .where.not(usx_style: "b") .order(usx_position: :asc)
   #                     sectioned_segments = Segment.group_in_sections(segments)
   #
   def self.group_in_sections(segments)

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -53,7 +53,7 @@
           <% when "d" %>
             <%# Label - Descriptive Title - Hebrew Subtitle %>
             <%= tag.div class: "mt-3 mb-3 text-center italic" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
@@ -61,7 +61,7 @@
           <% when "li1" %>
             <%# List Entry - Level 1 %>
             <%= tag.p class: "mt-3 pl-12 -indent-3" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
@@ -69,7 +69,7 @@
           <% when "li2" %>
             <%# List Entry - Level 2 %>
             <%= tag.p class: "mt-3 pl-21 -indent-3" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
@@ -77,7 +77,7 @@
           <% when "m" %>
             <%# Paragraph - Margin - No First Line Indent %>
             <%= tag.p class: "mt-3 pl-3 -indent-3" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
@@ -85,7 +85,7 @@
           <% when "mr" %>
             <%# Heading - Major Section Range References %>
             <%= tag.div class: "mt-3 mb-3 italic font-semibold" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <% next if ["(", ")"].include? fragment.content %>
 
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
@@ -94,13 +94,13 @@
 
           <% when "ms" %>
             <%# Heading - Major Section Level 1 %>
-            <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+            <% heading_title = segment.fragments.order(position: :asc)[0].content %>
             <%= tag.h3 heading_title, class: "mt-6 mb-3 text-xl font-semibold text-pretty text-gray-900 uppercase", id: heading_title.parameterize %>
 
           <% when "pc" %>
             <%# Paragraph - Centered (for Inscription) %>
             <%= tag.p class: "mt-1 text-center uppercase" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
@@ -108,7 +108,7 @@
           <% when "pmo" %>
             <%# Paragraph - Embedded Text Opening %>
             <%= tag.p class: "mt-3 pl-9 -indent-3" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
@@ -116,7 +116,7 @@
           <% when "q1" %>
             <%# Poetry - Indent Level 1 %>
             <%= tag.p class: "mt-1 pl-12 -indent-3" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
@@ -124,14 +124,14 @@
           <% when "q2" %>
             <%# Poetry - Indent Level 2 %>
             <%= tag.p class: "mt-1 pl-21 -indent-3" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
 
           <% when "qa" %>
             <%# Poetry - Acrostic Heading/Marker %>
-            <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+            <% heading_title = segment.fragments.order(position: :asc)[0].content %>
             <%= tag.div class: "mt-6 mb-3" do %>
               <div class="relative">
                 <div class="absolute inset-0 flex items-center" aria-hidden="true">
@@ -146,7 +146,7 @@
           <% when "qr" %>
             <%# Poetry - Right Aligned %>
             <%= tag.p class: "mt-3 text-right italic" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
               <% end %>
             <% end %>
@@ -154,7 +154,7 @@
           <% when "r" %>
             <%# Heading - Parallel References %>
             <%= tag.div class: "mt-3 mb-3 italic font-semibold" do %>
-              <% segment.fragments.order(segment_part: :asc).each do |fragment| %>
+              <% segment.fragments.order(position: :asc).each do |fragment| %>
                 <% next if ["(", ")"].include? fragment.content %>
 
                 <%= render partial: "fragment", locals: { fragment: fragment }  %>
@@ -163,17 +163,17 @@
 
           <% when "s1" %>
             <%# Heading - Section Level 1 %>
-            <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+            <% heading_title = segment.fragments.order(position: :asc)[0].content %>
             <%= tag.h3 heading_title, class: "mt-6 mb-3 text-xl font-semibold text-pretty text-gray-900", id: heading_title.parameterize %>
 
           <% when "s2" %>
             <%# Heading - Section Level 2 %>
-            <% heading_title = segment.fragments.order(segment_part: :asc)[0].content %>
+            <% heading_title = segment.fragments.order(position: :asc)[0].content %>
             <%= tag.h4 heading_title, class: "mt-6 mb-3 text-base font-semibold text-pretty text-gray-900", id: heading_title.parameterize %>
 
           <% else %>
             <%# ??? %>
-            <span>[<%= segment.usx_style %>] <%= segment%> - <%= segment.fragments.order(segment_part: :asc).size %></span>
+            <span>[<%= segment.usx_style %>] <%= segment%> - <%= segment.fragments.order(position: :asc).size %></span>
 
           <% end -%>
         <% end %>

--- a/db/migrate/20250209182506_create_segments.rb
+++ b/db/migrate/20250209182506_create_segments.rb
@@ -5,7 +5,7 @@ class CreateSegments < ActiveRecord::Migration[8.0]
       t.references :book, null: false, foreign_key: { on_delete: :restrict }
       t.references :chapter, null: false, foreign_key: { on_delete: :restrict }
       t.references :heading, null: false, foreign_key: { on_delete: :restrict }
-      t.integer :usx_node_id, null: false
+      t.integer :usx_position, null: false
       t.string :usx_style, null: false
 
       t.timestamps

--- a/db/migrate/20250209182507_create_fragments.rb
+++ b/db/migrate/20250209182507_create_fragments.rb
@@ -10,7 +10,7 @@ class CreateFragments < ActiveRecord::Migration[8.0]
       t.boolean :show_verse, null: false
       t.string :kind, null: false
       t.text :content, null: false
-      t.integer :segment_part, null: false
+      t.integer :position, null: false
       t.belongs_to :fragmentable, polymorphic: true, null: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_23_090004) do
     t.boolean "show_verse", null: false
     t.string "kind", null: false
     t.text "content", null: false
-    t.integer "segment_part", null: false
+    t.integer "position", null: false
     t.string "fragmentable_type"
     t.bigint "fragmentable_id"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -129,7 +129,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_23_090004) do
     t.bigint "book_id", null: false
     t.bigint "chapter_id", null: false
     t.bigint "heading_id", null: false
-    t.integer "usx_node_id", null: false
+    t.integer "usx_position", null: false
     t.string "usx_style", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,7 +88,7 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
         Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter.number} Heading #{heading.level} (#{heading.title})"
       end
 
-      segment = Segment.create!(bible: bible, book: book, chapter: chapter, heading: heading, usx_node_id: segment_node_id, usx_style: segment_style)
+      segment = Segment.create!(bible: bible, book: book, chapter: chapter, heading: heading, usx_position: segment_node_id, usx_style: segment_style)
       Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter&.number} Segment #{segment.id}"
 
       segment_node.children.each.with_index(1) do |fragment_node, fragment_number|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -133,7 +133,7 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
 
         next if fragment_text.empty?
 
-        fragment = Fragment.create!(bible: bible, book: book, segment: segment, chapter: chapter, heading: heading, verse: verse, kind: fragment_kind, show_verse: show_verse, content: fragment_text, segment_part: fragment_number, fragmentable: fragmentable)
+        fragment = Fragment.create!(bible: bible, book: book, segment: segment, chapter: chapter, heading: heading, verse: verse, kind: fragment_kind, show_verse: show_verse, content: fragment_text, position: fragment_number, fragmentable: fragmentable)
         show_verse = false if fragment.show_verse
         Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter&.number} Segment #{segment.id} Fragment #{fragment.id} (#{fragment.content})"
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,8 +56,8 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
   chapter = nil
   heading = nil
   verse = nil
-  book_content.root.children.each.with_index(1) do |segment_node, segment_node_id|
-    next if Rails.env.test? && segment_node_id > 50
+  book_content.root.children.each.with_index(1) do |segment_node, segment_position|
+    next if Rails.env.test? && segment_position > 50
 
     show_verse = false
 
@@ -88,10 +88,10 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
         Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter.number} Heading #{heading.level} (#{heading.title})"
       end
 
-      segment = Segment.create!(bible: bible, book: book, chapter: chapter, heading: heading, usx_position: segment_node_id, usx_style: segment_style)
+      segment = Segment.create!(bible: bible, book: book, chapter: chapter, heading: heading, usx_position: segment_position, usx_style: segment_style)
       Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter&.number} Segment #{segment.id}"
 
-      segment_node.children.each.with_index(1) do |fragment_node, fragment_number|
+      segment_node.children.each.with_index(1) do |fragment_node, fragment_position|
         fragment_text = fragment_node.text.strip
         fragment_kind = nil
         fragmentable = nil
@@ -133,7 +133,7 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
 
         next if fragment_text.empty?
 
-        fragment = Fragment.create!(bible: bible, book: book, segment: segment, chapter: chapter, heading: heading, verse: verse, kind: fragment_kind, show_verse: show_verse, content: fragment_text, position: fragment_number, fragmentable: fragmentable)
+        fragment = Fragment.create!(bible: bible, book: book, segment: segment, chapter: chapter, heading: heading, verse: verse, kind: fragment_kind, show_verse: show_verse, content: fragment_text, position: fragment_position, fragmentable: fragmentable)
         show_verse = false if fragment.show_verse
         Rails.logger.info "Seeded Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter&.number} Segment #{segment.id} Fragment #{fragment.id} (#{fragment.content})"
       end


### PR DESCRIPTION
This pull request includes several changes to the `Fragment` and `Segment` models, as well as updates to the associated views, migrations, and seeds. The primary focus of these changes is to rename the `segment_part` attribute to `position` in the `Fragment` model and the `usx_node_id` attribute to `usx_position` in the `Segment` model.

Here are some column name suggestions for explicitly storing the order of a record in your Rails model:

- `position` – A common and intuitive choice.
- `sort_order` – Clearly indicates its purpose.
- `display_order` – Useful if the order is mainly for UI presentation.
- `priority` – Works well if higher values indicate higher priority.
- `sequence` – Good if the order follows a sequential logic.
- `listing_order` – Explicit if the order is used in listings.
- `index` – Simple, but may conflict with database reserved words.

I chose `position` as it's widely used in Rails apps and works well with gems like [acts_as_list](https://github.com/brendon/acts_as_list).

### Changes

#### Changes to Models:

* `app/models/fragment.rb`: Renamed `segment_part` to `position` in the schema comments and validations.
* `app/models/segment.rb`: Renamed `usx_node_id` to `usx_position` in the schema comments, validations, and example code.

#### Changes to Views:

* `app/views/chapters/show.html.erb`: Updated the order method from `segment_part` to `position` in multiple places to reflect the attribute renaming.

#### Changes to Migrations:

* `db/migrate/20250209182506_create_segments.rb`: Changed `usx_node_id` to `usx_position`.
* `db/migrate/20250209182507_create_fragments.rb`: Changed `segment_part` to `position`.

#### Changes to Seeds:

* `db/seeds.rb`: Updated the seeding logic to use `usx_position` instead of `usx_node_id` and `position` instead of `segment_part`.

#### Changes to Schema:

* `db/schema.rb`: Updated the schema to reflect the changes in the `Fragment` and `Segment` models.

These changes ensure consistency across the codebase by aligning attribute names with their intended use.