### PR TITLE
Add section logic powered by a Section model

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -16,9 +16,7 @@ class ChaptersController < ApplicationController
     @bible = Bible.find_by! code: bible_code
     @book = Book.find_by! bible: @bible, slug: book_slug
     @chapter = Chapter.find_by! bible: @bible, book: @book, number: chapter_number
-
-    segments = Segment.where(bible: @bible, book: @book, chapter: @chapter).where.not(usx_style: "b").order(usx_position: :asc)
-    @sectioned_segments = Segment.group_in_sections(segments)
+    @sections = Section.where(bible: @bible, book: @book, chapter: @chapter).order(position: :asc)
 
     @footnotes_mapping = {}
     @footnotes = Footnote.where(bible: @bible, book: @book, chapter: @chapter).order(created_at: :asc)

--- a/app/models/bible.rb
+++ b/app/models/bible.rb
@@ -28,6 +28,7 @@ class Bible < ApplicationRecord
   has_many :fragments, dependent: :restrict_with_error
   has_many :headings, dependent: :restrict_with_error
   has_many :references, dependent: :restrict_with_error
+  has_many :sections, dependent: :restrict_with_error
   has_many :segments, dependent: :restrict_with_error
   has_many :verses, dependent: :restrict_with_error
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -37,6 +37,7 @@ class Book < ApplicationRecord
   has_many :fragments, dependent: :restrict_with_error
   has_many :headings, dependent: :restrict_with_error
   has_many :references, dependent: :restrict_with_error
+  has_many :sections, dependent: :restrict_with_error
   has_many :segments, dependent: :restrict_with_error
   has_many :verses, dependent: :restrict_with_error
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -39,6 +39,7 @@ class Chapter < ApplicationRecord
   has_many :fragments, dependent: :restrict_with_error
   has_many :headings, dependent: :restrict_with_error
   has_many :references, dependent: :restrict_with_error
+  has_many :sections, dependent: :restrict_with_error
   has_many :segments, dependent: :restrict_with_error
   has_many :verses, dependent: :restrict_with_error
 

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -41,6 +41,7 @@ class Heading < ApplicationRecord
   belongs_to :chapter
   has_many :fragments, dependent: :restrict_with_error
   has_many :references, dependent: :restrict_with_error
+  has_many :sections, dependent: :restrict_with_error
   has_many :segments, dependent: :restrict_with_error
 
   # Validations

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,3 +1,42 @@
+# ## Schema Information
+#
+# Table name: `sections`
+#
+# ### Columns
+#
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`position`**    | `integer`          | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`bible_id`**    | `bigint`           | `not null`
+# **`book_id`**     | `bigint`           | `not null`
+# **`chapter_id`**  | `bigint`           | `not null`
+# **`heading_id`**  | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_sections_on_bible_id`:
+#     * **`bible_id`**
+# * `index_sections_on_book_id`:
+#     * **`book_id`**
+# * `index_sections_on_chapter_id`:
+#     * **`chapter_id`**
+# * `index_sections_on_heading_id`:
+#     * **`heading_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`bible_id => bibles.id`**
+# * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`book_id => books.id`**
+# * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`chapter_id => chapters.id`**
+# * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`heading_id => headings.id`**
+#
 class Section < ApplicationRecord
   # Associations
   belongs_to :bible

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -43,6 +43,8 @@ class Section < ApplicationRecord
   belongs_to :book
   belongs_to :chapter
   belongs_to :heading
+  has_many :section_segment_associations, dependent: :destroy
+  has_many :segments, through: :section_segment_associations
 
   # Validations
   validates :bible, presence: true

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,0 +1,14 @@
+class Section < ApplicationRecord
+  # Associations
+  belongs_to :bible
+  belongs_to :book
+  belongs_to :chapter
+  belongs_to :heading
+
+  # Validations
+  validates :bible, presence: true
+  validates :book, presence: true
+  validates :chapter, presence: true
+  validates :heading, presence: true
+  validates :position, presence: true, numericality: { only_integer: true, greater_than: 0 }
+end

--- a/app/models/section_segment_association.rb
+++ b/app/models/section_segment_association.rb
@@ -1,3 +1,31 @@
+# ## Schema Information
+#
+# Table name: `section_segment_associations`
+#
+# ### Columns
+#
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`section_id`**  | `bigint`           | `not null`
+# **`segment_id`**  | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_section_segment_associations_on_section_id`:
+#     * **`section_id`**
+# * `index_section_segment_associations_on_segment_id`:
+#     * **`segment_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`section_id => sections.id`**
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`segment_id => segments.id`**
+#
 class SectionSegmentAssociation < ApplicationRecord
   # Associations
   belongs_to :section

--- a/app/models/section_segment_association.rb
+++ b/app/models/section_segment_association.rb
@@ -1,0 +1,9 @@
+class SectionSegmentAssociation < ApplicationRecord
+  # Associations
+  belongs_to :section
+  belongs_to :segment
+
+  # Validations
+  validates :section, presence: true
+  validates :segment, presence: true
+end

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -45,6 +45,8 @@ class Segment < ApplicationRecord
   belongs_to :chapter
   belongs_to :heading
   has_many :fragments, dependent: :restrict_with_error
+  has_many :section_segment_associations, dependent: :destroy
+  has_many :sections, through: :section_segment_associations
   has_many :segment_verse_associations, dependent: :destroy
   has_many :verses, through: :segment_verse_associations
 

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -59,7 +59,6 @@ class Segment < ApplicationRecord
   validates :usx_style, presence: true
 
   # Constants
-  CONTENT_STYLES = [ :li1, :li2, :m, :pc, :pmo, :q1, :q2, :qa, :qr ]
   GROUPABLE_STYLES = [ :li1, :li2, :pc, :q1, :q2 ]
   HEADER_STYLES_INTRODUCTORY = [ "h", "toc2", "toc1", "mt1" ]
   HEADER_STYLES_SECTIONS_MAJOR = { ms: 0, ms1: 1, ms2: 2, ms3: 3, ms4: 4 }
@@ -104,7 +103,7 @@ class Segment < ApplicationRecord
     # * `qa` - Poetry - Acrostic Heading/Marker
     # * `qr` - Poetry - Right Aligned
     segments.chunk_while do |previous_segment, next_segment|
-      if CONTENT_STYLES.include? next_segment.usx_style.to_sym
+      if GROUPABLE_STYLES.include? next_segment.usx_style.to_sym
         # If we have groupable styles following each other group them into the
         # same section.
         groupable = GROUPABLE_STYLES.include?(previous_segment.usx_style.to_sym) && GROUPABLE_STYLES.include?(next_segment.usx_style.to_sym)

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -59,7 +59,7 @@ class Segment < ApplicationRecord
   validates :usx_style, presence: true
 
   # Constants
-  GROUPABLE_STYLES = [ :li1, :li2, :pc, :q1, :q2 ]
+  GROUPABLE_STYLES = [ :li1, :li2, :pc, :q1, :q2, :qr ]
   HEADER_STYLES_INTRODUCTORY = [ "h", "toc2", "toc1", "mt1" ]
   HEADER_STYLES_SECTIONS_MAJOR = { ms: 0, ms1: 1, ms2: 2, ms3: 3, ms4: 4 }
   HEADER_STYLES_SECTIONS_MINOR = { s: 0, s1: 1, s2: 2, s3: 3, s4: 4 }
@@ -112,7 +112,7 @@ class Segment < ApplicationRecord
         # following each other it makes sense to stylistically group them
         # following based on their levels.
         groupable_list = [ "li1", "li2" ].include?(previous_segment.usx_style) && next_segment.usx_style == "li2"
-        groupable_poetry = [ "q1", "q2" ].include?(previous_segment.usx_style) && next_segment.usx_style == "q2"
+        groupable_poetry = [ "q1", "q2" ].include?(previous_segment.usx_style) && [ "q2", "qr" ].include?(next_segment.usx_style)
 
         # It makes sense to keep inscriptions in the same section as they
         # contextually related.

--- a/app/models/segment_verse_association.rb
+++ b/app/models/segment_verse_association.rb
@@ -32,6 +32,6 @@ class SegmentVerseAssociation < ApplicationRecord
   belongs_to :verse
 
   # Validations
-  validates :segment_id, presence: true
-  validates :verse_id, presence: true
+  validates :segment, presence: true
+  validates :verse, presence: true
 end

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -41,9 +41,9 @@
   <section class="my-6" id="chapter">
     <h2 class="text-3xl font-semibold text-pretty text-gray-900"><%= "Chapter #{@chapter.number}" %></h2>
 
-    <% @sectioned_segments.each_with_index do |section_segments, section_index| %>
-      <%= tag.div id: "section-#{section_index}" do %>
-        <% section_segments.each do |segment| %>
+    <% @sections.each do |section| %>
+      <%= tag.div id: "section-#{section.id}" do %>
+        <% section.segments.each do |segment| %>
           <%# "[#{segment.usx_style}, #{segment.verses.ids}]" unless segment.usx_style == "b" %>
 
           <% case segment.usx_style -%>

--- a/db/migrate/20250324211317_create_sections.rb
+++ b/db/migrate/20250324211317_create_sections.rb
@@ -1,0 +1,13 @@
+class CreateSections < ActiveRecord::Migration[8.0]
+  def change
+    create_table :sections do |t|
+      t.references :bible, null: false, foreign_key: { on_delete: :restrict }
+      t.references :book, null: false, foreign_key: { on_delete: :restrict }
+      t.references :chapter, null: false, foreign_key: { on_delete: :restrict }
+      t.references :heading, null: false, foreign_key: { on_delete: :restrict }
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250324211829_create_section_segment_associations.rb
+++ b/db/migrate/20250324211829_create_section_segment_associations.rb
@@ -1,0 +1,10 @@
+class CreateSectionSegmentAssociations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :section_segment_associations do |t|
+      t.references :section, null: false, foreign_key: { on_delete: :cascade }
+      t.references :segment, null: false, foreign_key: { on_delete: :cascade }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_24_211317) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_24_211829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -115,6 +115,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_24_211317) do
     t.index ["heading_id"], name: "index_references_on_heading_id"
   end
 
+  create_table "section_segment_associations", force: :cascade do |t|
+    t.bigint "section_id", null: false
+    t.bigint "segment_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["section_id"], name: "index_section_segment_associations_on_section_id"
+    t.index ["segment_id"], name: "index_section_segment_associations_on_segment_id"
+  end
+
   create_table "sections", force: :cascade do |t|
     t.bigint "bible_id", null: false
     t.bigint "book_id", null: false
@@ -186,6 +195,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_24_211317) do
   add_foreign_key "references", "books", on_delete: :restrict
   add_foreign_key "references", "chapters", on_delete: :restrict
   add_foreign_key "references", "headings", on_delete: :restrict
+  add_foreign_key "section_segment_associations", "sections", on_delete: :cascade
+  add_foreign_key "section_segment_associations", "segments", on_delete: :cascade
   add_foreign_key "sections", "bibles", on_delete: :restrict
   add_foreign_key "sections", "books", on_delete: :restrict
   add_foreign_key "sections", "chapters", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_23_090004) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_24_211317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -115,6 +115,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_23_090004) do
     t.index ["heading_id"], name: "index_references_on_heading_id"
   end
 
+  create_table "sections", force: :cascade do |t|
+    t.bigint "bible_id", null: false
+    t.bigint "book_id", null: false
+    t.bigint "chapter_id", null: false
+    t.bigint "heading_id", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bible_id"], name: "index_sections_on_bible_id"
+    t.index ["book_id"], name: "index_sections_on_book_id"
+    t.index ["chapter_id"], name: "index_sections_on_chapter_id"
+    t.index ["heading_id"], name: "index_sections_on_heading_id"
+  end
+
   create_table "segment_verse_associations", force: :cascade do |t|
     t.bigint "segment_id", null: false
     t.bigint "verse_id", null: false
@@ -172,6 +186,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_23_090004) do
   add_foreign_key "references", "books", on_delete: :restrict
   add_foreign_key "references", "chapters", on_delete: :restrict
   add_foreign_key "references", "headings", on_delete: :restrict
+  add_foreign_key "sections", "bibles", on_delete: :restrict
+  add_foreign_key "sections", "books", on_delete: :restrict
+  add_foreign_key "sections", "chapters", on_delete: :restrict
+  add_foreign_key "sections", "headings", on_delete: :restrict
   add_foreign_key "segment_verse_associations", "segments", on_delete: :cascade
   add_foreign_key "segment_verse_associations", "verses", on_delete: :cascade
   add_foreign_key "segments", "bibles", on_delete: :restrict


### PR DESCRIPTION
This pull request introduces a new `Section` model and integrates it into the existing data structure for better organization of segments within chapters. The changes include adding new associations, updating existing models, and modifying the database schema.

### Changes

#### Model and Association Updates

* Added `has_many :sections` association to `Bible`, `Book`, `Chapter`, and `Heading` models to establish relationships with the new `Section` model.
* Updated `Segment` model to include associations with `Section` through a join table `section_segment_associations`.

#### New Models

* Created `Section` model with associations to `Bible`, `Book`, `Chapter`, `Heading`, and `Segment`. Added validations for presence and numericality constraints.
* Created `SectionSegmentAssociation` model to manage many-to-many relationships between `Section` and `Segment`.

#### Database Schema Changes

* Added migrations to create `sections` and `section_segment_associations` tables with appropriate foreign keys and indexes.
* Updated `schema.rb` to reflect the new tables and associations.

#### Controller and View Updates

* Modified `ChaptersController#show` to retrieve and display sections instead of directly handling segments.
* Updated `show.html.erb` view to iterate over sections and their associated segments.

#### Additional Changes

* Updated `seeds.rb` to chunk segments into sections during seeding.