### PR TITLE
Set up commentary model structure i.e. Exposition

### DIFF
--- a/app/models/exposition.rb
+++ b/app/models/exposition.rb
@@ -1,0 +1,5 @@
+module Exposition
+  def self.table_name_prefix
+    "exposition_"
+  end
+end

--- a/app/models/exposition/alternative_interpretation.rb
+++ b/app/models/exposition/alternative_interpretation.rb
@@ -1,0 +1,34 @@
+# ## Schema Information
+#
+# Table name: `exposition_alternative_interpretations`
+#
+# ### Columns
+#
+# Name                         | Type               | Attributes
+# ---------------------------- | ------------------ | ---------------------------
+# **`id`**                     | `bigint`           | `not null, primary key`
+# **`note`**                   | `string`           | `not null`
+# **`title`**                  | `string`           | `not null`
+# **`created_at`**             | `datetime`         | `not null`
+# **`updated_at`**             | `datetime`         | `not null`
+# **`exposition_content_id`**  | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `idx_on_exposition_content_id_705a740ad5`:
+#     * **`exposition_content_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`exposition_content_id => exposition_contents.id`**
+#
+class Exposition::AlternativeInterpretation < ApplicationRecord
+  # Associations
+  belongs_to :exposition_content
+
+  # Validations
+  validates :exposition_content, presence: true
+  validates :note, presence: true
+  validates :title, presence: true
+end

--- a/app/models/exposition/analysis.rb
+++ b/app/models/exposition/analysis.rb
@@ -1,0 +1,36 @@
+# ## Schema Information
+#
+# Table name: `exposition_analyses`
+#
+# ### Columns
+#
+# Name                         | Type               | Attributes
+# ---------------------------- | ------------------ | ---------------------------
+# **`id`**                     | `bigint`           | `not null, primary key`
+# **`note`**                   | `string`           | `not null`
+# **`position`**               | `integer`          | `not null`
+# **`section`**                | `string`           | `not null`
+# **`created_at`**             | `datetime`         | `not null`
+# **`updated_at`**             | `datetime`         | `not null`
+# **`exposition_content_id`**  | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_exposition_analyses_on_exposition_content_id`:
+#     * **`exposition_content_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`exposition_content_id => exposition_contents.id`**
+#
+class Exposition::Analysis < ApplicationRecord
+  # Associations
+  belongs_to :exposition_content
+
+  # Validations
+  validates :exposition_content, presence: true
+  validates :note, presence: true
+  validates :position, presence: true
+  validates :section, presence: true
+end

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -47,6 +47,7 @@ class Exposition::Content < ApplicationRecord
   has_many :exposition_cross_references, dependent: :destroy
   has_many :exposition_insights, dependent: :destroy
   has_many :exposition_key_themes, dependent: :destroy
+  has_many :exposition_personal_applications, dependent: :destroy
 
   # Validations
   validates :context, presence: true

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -46,6 +46,7 @@ class Exposition::Content < ApplicationRecord
   has_many :exposition_analyses, dependent: :destroy
   has_many :exposition_cross_references, dependent: :destroy
   has_many :exposition_insights, dependent: :destroy
+  has_many :exposition_key_themes, dependent: :destroy
 
   # Validations
   validates :context, presence: true

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -44,6 +44,7 @@ class Exposition::Content < ApplicationRecord
   belongs_to :section
   has_many :exposition_alternative_interpretations, dependent: :destroy
   has_many :exposition_analyses, dependent: :destroy
+  has_many :exposition_cross_references, dependent: :destroy
 
   # Validations
   validates :context, presence: true

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -45,6 +45,7 @@ class Exposition::Content < ApplicationRecord
   has_many :exposition_alternative_interpretations, dependent: :destroy
   has_many :exposition_analyses, dependent: :destroy
   has_many :exposition_cross_references, dependent: :destroy
+  has_many :exposition_insights, dependent: :destroy
 
   # Validations
   validates :context, presence: true

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -43,6 +43,7 @@ class Exposition::Content < ApplicationRecord
   # Associations
   belongs_to :section
   has_many :exposition_alternative_interpretations, dependent: :destroy
+  has_many :exposition_analyses, dependent: :destroy
 
   # Validations
   validates :context, presence: true

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -1,0 +1,57 @@
+# ## Schema Information
+#
+# Table name: `exposition_contents`
+#
+# ### Columns
+#
+# Name                       | Type               | Attributes
+# -------------------------- | ------------------ | ---------------------------
+# **`id`**                   | `bigint`           | `not null, primary key`
+# **`context`**              | `string`           | `not null`
+# **`highlights`**           | `string`           | `default([]), not null, is an Array`
+# **`interpretation_type`**  | `string`           | `not null`
+# **`people`**               | `string`           | `default([]), not null, is an Array`
+# **`places`**               | `string`           | `default([]), not null, is an Array`
+# **`reflections`**          | `string`           | `default([]), not null, is an Array`
+# **`summary`**              | `text`             | `not null`
+# **`tags`**                 | `string`           | `default([]), not null, is an Array`
+# **`created_at`**           | `datetime`         | `not null`
+# **`updated_at`**           | `datetime`         | `not null`
+# **`section_id`**           | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_exposition_contents_on_highlights` (_using_ gin):
+#     * **`highlights`**
+# * `index_exposition_contents_on_people` (_using_ gin):
+#     * **`people`**
+# * `index_exposition_contents_on_places` (_using_ gin):
+#     * **`places`**
+# * `index_exposition_contents_on_reflections` (_using_ gin):
+#     * **`reflections`**
+# * `index_exposition_contents_on_section_id`:
+#     * **`section_id`**
+# * `index_exposition_contents_on_tags` (_using_ gin):
+#     * **`tags`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`section_id => sections.id`**
+#
+class Exposition::Content < ApplicationRecord
+  # Associations
+  belongs_to :section
+
+  # Validations
+  validates :context, presence: true
+  validates :highlights, presence: true
+  validates :interpretation_type, presence: true
+  validates :reflections, presence: true
+  validates :section, presence: true
+  validates :summary, presence: true
+  validates :tags, presence: true
+
+  # Enums
+  enum :interpretation_type, { majority: "majority", minority:  "minority" }
+end

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -42,6 +42,7 @@
 class Exposition::Content < ApplicationRecord
   # Associations
   belongs_to :section
+  has_many :exposition_alternative_interpretations, dependent: :destroy
 
   # Validations
   validates :context, presence: true

--- a/app/models/exposition/cross_reference.rb
+++ b/app/models/exposition/cross_reference.rb
@@ -1,0 +1,34 @@
+# ## Schema Information
+#
+# Table name: `exposition_cross_references`
+#
+# ### Columns
+#
+# Name                         | Type               | Attributes
+# ---------------------------- | ------------------ | ---------------------------
+# **`id`**                     | `bigint`           | `not null, primary key`
+# **`note`**                   | `string`           | `not null`
+# **`reference`**              | `string`           | `not null`
+# **`created_at`**             | `datetime`         | `not null`
+# **`updated_at`**             | `datetime`         | `not null`
+# **`exposition_content_id`**  | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_exposition_cross_references_on_exposition_content_id`:
+#     * **`exposition_content_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`exposition_content_id => exposition_contents.id`**
+#
+class Exposition::CrossReference < ApplicationRecord
+  # Associations
+  belongs_to :exposition_content
+
+  # Validations
+  validates :exposition_content, presence: true
+  validates :note, presence: true
+  validates :reference, presence: true
+end

--- a/app/models/exposition/insight.rb
+++ b/app/models/exposition/insight.rb
@@ -1,0 +1,37 @@
+# ## Schema Information
+#
+# Table name: `exposition_insights`
+#
+# ### Columns
+#
+# Name                         | Type               | Attributes
+# ---------------------------- | ------------------ | ---------------------------
+# **`id`**                     | `bigint`           | `not null, primary key`
+# **`kind`**                   | `string`           | `not null`
+# **`note`**                   | `string`           | `not null`
+# **`created_at`**             | `datetime`         | `not null`
+# **`updated_at`**             | `datetime`         | `not null`
+# **`exposition_content_id`**  | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_exposition_insights_on_exposition_content_id`:
+#     * **`exposition_content_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`exposition_content_id => exposition_contents.id`**
+#
+class Exposition::Insight < ApplicationRecord
+  # Associations
+  belongs_to :exposition_content
+
+  # Validations
+  validates :exposition_content, presence: true
+  validates :kind, presence: true
+  validates :note, presence: true
+
+  # Enums
+  enum :kind, { personal: "personal" }
+end

--- a/app/models/exposition/key_theme.rb
+++ b/app/models/exposition/key_theme.rb
@@ -1,0 +1,34 @@
+# ## Schema Information
+#
+# Table name: `exposition_key_themes`
+#
+# ### Columns
+#
+# Name                         | Type               | Attributes
+# ---------------------------- | ------------------ | ---------------------------
+# **`id`**                     | `bigint`           | `not null, primary key`
+# **`description`**            | `string`           | `not null`
+# **`theme`**                  | `string`           | `not null`
+# **`created_at`**             | `datetime`         | `not null`
+# **`updated_at`**             | `datetime`         | `not null`
+# **`exposition_content_id`**  | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `index_exposition_key_themes_on_exposition_content_id`:
+#     * **`exposition_content_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`exposition_content_id => exposition_contents.id`**
+#
+class Exposition::KeyTheme < ApplicationRecord
+  # Associations
+  belongs_to :exposition_content
+
+  # Validations
+  validates :description, presence: true
+  validates :exposition_content, presence: true
+  validates :theme, presence: true
+end

--- a/app/models/exposition/personal_application.rb
+++ b/app/models/exposition/personal_application.rb
@@ -1,0 +1,34 @@
+# ## Schema Information
+#
+# Table name: `exposition_personal_applications`
+#
+# ### Columns
+#
+# Name                         | Type               | Attributes
+# ---------------------------- | ------------------ | ---------------------------
+# **`id`**                     | `bigint`           | `not null, primary key`
+# **`note`**                   | `string`           | `not null`
+# **`title`**                  | `string`           | `not null`
+# **`created_at`**             | `datetime`         | `not null`
+# **`updated_at`**             | `datetime`         | `not null`
+# **`exposition_content_id`**  | `bigint`           | `not null`
+#
+# ### Indexes
+#
+# * `idx_on_exposition_content_id_b900e2aa68`:
+#     * **`exposition_content_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => cascade_):
+#     * **`exposition_content_id => exposition_contents.id`**
+#
+class Exposition::PersonalApplication < ApplicationRecord
+  # Associations
+  belongs_to :exposition_content
+
+  # Validations
+  validates :exposition_content, presence: true
+  validates :note, presence: true
+  validates :title, presence: true
+end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -45,6 +45,7 @@ class Section < ApplicationRecord
   belongs_to :heading
   has_many :section_segment_associations, dependent: :destroy
   has_many :segments, through: :section_segment_associations
+  has_one :exposition_content, dependent: :restrict_with_error
 
   # Validations
   validates :bible, presence: true

--- a/db/migrate/20250329013742_create_exposition_contents.rb
+++ b/db/migrate/20250329013742_create_exposition_contents.rb
@@ -1,0 +1,23 @@
+class CreateExpositionContents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_contents do |t|
+      t.references :section, null: false, foreign_key: { on_delete: :restrict }
+      t.text :summary, null: false
+      t.string :context, null: false
+      t.string :highlights, null: false, array: true, default: []
+      t.string :reflections, null: false, array: true, default: []
+      t.string :interpretation_type, null: false
+      t.string :people, null: false, array: true, default: []
+      t.string :places, null: false, array: true, default: []
+      t.string :tags, null: false, array: true, default: []
+
+      t.timestamps
+    end
+
+    add_index :exposition_contents, :highlights, using: :gin
+    add_index :exposition_contents, :reflections, using: :gin
+    add_index :exposition_contents, :people, using: :gin
+    add_index :exposition_contents, :places, using: :gin
+    add_index :exposition_contents, :tags, using: :gin
+  end
+end

--- a/db/migrate/20250329015205_create_exposition_alternative_interpretations.rb
+++ b/db/migrate/20250329015205_create_exposition_alternative_interpretations.rb
@@ -1,0 +1,11 @@
+class CreateExpositionAlternativeInterpretations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_alternative_interpretations do |t|
+      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.string :title, null: false
+      t.string :note, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250329020042_create_exposition_analyses.rb
+++ b/db/migrate/20250329020042_create_exposition_analyses.rb
@@ -1,0 +1,12 @@
+class CreateExpositionAnalyses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_analyses do |t|
+      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.string :section, null: false
+      t.string :note, null: false
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250329020938_create_exposition_cross_references.rb
+++ b/db/migrate/20250329020938_create_exposition_cross_references.rb
@@ -1,0 +1,11 @@
+class CreateExpositionCrossReferences < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_cross_references do |t|
+      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.string :reference, null: false
+      t.string :note, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250329021421_create_exposition_insights.rb
+++ b/db/migrate/20250329021421_create_exposition_insights.rb
@@ -1,0 +1,11 @@
+class CreateExpositionInsights < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_insights do |t|
+      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.string :kind, null: false
+      t.string :note, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250329021817_create_exposition_key_themes.rb
+++ b/db/migrate/20250329021817_create_exposition_key_themes.rb
@@ -1,0 +1,11 @@
+class CreateExpositionKeyThemes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_key_themes do |t|
+      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.string :theme, null: false
+      t.string :description, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250329022208_create_exposition_personal_applications.rb
+++ b/db/migrate/20250329022208_create_exposition_personal_applications.rb
@@ -1,0 +1,11 @@
+class CreateExpositionPersonalApplications < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_personal_applications do |t|
+      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.string :title, null: false
+      t.string :note, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_020938) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_021421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -95,6 +95,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_020938) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exposition_content_id"], name: "index_exposition_cross_references_on_exposition_content_id"
+  end
+
+  create_table "exposition_insights", force: :cascade do |t|
+    t.bigint "exposition_content_id", null: false
+    t.string "kind", null: false
+    t.string "note", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exposition_content_id"], name: "index_exposition_insights_on_exposition_content_id"
   end
 
   create_table "footnotes", force: :cascade do |t|
@@ -230,6 +239,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_020938) do
   add_foreign_key "exposition_analyses", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_contents", "sections", on_delete: :restrict
   add_foreign_key "exposition_cross_references", "exposition_contents", on_delete: :cascade
+  add_foreign_key "exposition_insights", "exposition_contents", on_delete: :cascade
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict
   add_foreign_key "footnotes", "chapters", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_021421) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_021817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -104,6 +104,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_021421) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exposition_content_id"], name: "index_exposition_insights_on_exposition_content_id"
+  end
+
+  create_table "exposition_key_themes", force: :cascade do |t|
+    t.bigint "exposition_content_id", null: false
+    t.string "theme", null: false
+    t.string "description", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exposition_content_id"], name: "index_exposition_key_themes_on_exposition_content_id"
   end
 
   create_table "footnotes", force: :cascade do |t|
@@ -240,6 +249,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_021421) do
   add_foreign_key "exposition_contents", "sections", on_delete: :restrict
   add_foreign_key "exposition_cross_references", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_insights", "exposition_contents", on_delete: :cascade
+  add_foreign_key "exposition_key_themes", "exposition_contents", on_delete: :cascade
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict
   add_foreign_key "footnotes", "chapters", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_021817) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_022208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -113,6 +113,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_021817) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exposition_content_id"], name: "index_exposition_key_themes_on_exposition_content_id"
+  end
+
+  create_table "exposition_personal_applications", force: :cascade do |t|
+    t.bigint "exposition_content_id", null: false
+    t.string "title", null: false
+    t.string "note", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exposition_content_id"], name: "idx_on_exposition_content_id_b900e2aa68"
   end
 
   create_table "footnotes", force: :cascade do |t|
@@ -250,6 +259,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_021817) do
   add_foreign_key "exposition_cross_references", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_insights", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_key_themes", "exposition_contents", on_delete: :cascade
+  add_foreign_key "exposition_personal_applications", "exposition_contents", on_delete: :cascade
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict
   add_foreign_key "footnotes", "chapters", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_24_211829) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_013742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,6 +47,26 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_24_211829) do
     t.index ["bible_id", "book_id", "number"], name: "index_chapters_on_bible_id_and_book_id_and_number", unique: true
     t.index ["bible_id"], name: "index_chapters_on_bible_id"
     t.index ["book_id"], name: "index_chapters_on_book_id"
+  end
+
+  create_table "exposition_contents", force: :cascade do |t|
+    t.bigint "section_id", null: false
+    t.text "summary", null: false
+    t.string "context", null: false
+    t.string "highlights", default: [], null: false, array: true
+    t.string "reflections", default: [], null: false, array: true
+    t.string "interpretation_type", null: false
+    t.string "people", default: [], null: false, array: true
+    t.string "places", default: [], null: false, array: true
+    t.string "tags", default: [], null: false, array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["highlights"], name: "index_exposition_contents_on_highlights", using: :gin
+    t.index ["people"], name: "index_exposition_contents_on_people", using: :gin
+    t.index ["places"], name: "index_exposition_contents_on_places", using: :gin
+    t.index ["reflections"], name: "index_exposition_contents_on_reflections", using: :gin
+    t.index ["section_id"], name: "index_exposition_contents_on_section_id"
+    t.index ["tags"], name: "index_exposition_contents_on_tags", using: :gin
   end
 
   create_table "footnotes", force: :cascade do |t|
@@ -178,6 +198,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_24_211829) do
   add_foreign_key "books", "bibles", on_delete: :restrict
   add_foreign_key "chapters", "bibles", on_delete: :restrict
   add_foreign_key "chapters", "books", on_delete: :restrict
+  add_foreign_key "exposition_contents", "sections", on_delete: :restrict
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict
   add_foreign_key "footnotes", "chapters", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_013742) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_015205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,6 +47,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_013742) do
     t.index ["bible_id", "book_id", "number"], name: "index_chapters_on_bible_id_and_book_id_and_number", unique: true
     t.index ["bible_id"], name: "index_chapters_on_bible_id"
     t.index ["book_id"], name: "index_chapters_on_book_id"
+  end
+
+  create_table "exposition_alternative_interpretations", force: :cascade do |t|
+    t.bigint "exposition_content_id", null: false
+    t.string "title", null: false
+    t.string "note", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exposition_content_id"], name: "idx_on_exposition_content_id_705a740ad5"
   end
 
   create_table "exposition_contents", force: :cascade do |t|
@@ -198,6 +207,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_013742) do
   add_foreign_key "books", "bibles", on_delete: :restrict
   add_foreign_key "chapters", "bibles", on_delete: :restrict
   add_foreign_key "chapters", "books", on_delete: :restrict
+  add_foreign_key "exposition_alternative_interpretations", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_contents", "sections", on_delete: :restrict
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_015205) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_020042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -56,6 +56,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_015205) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exposition_content_id"], name: "idx_on_exposition_content_id_705a740ad5"
+  end
+
+  create_table "exposition_analyses", force: :cascade do |t|
+    t.bigint "exposition_content_id", null: false
+    t.string "section", null: false
+    t.string "note", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exposition_content_id"], name: "index_exposition_analyses_on_exposition_content_id"
   end
 
   create_table "exposition_contents", force: :cascade do |t|
@@ -208,6 +218,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_015205) do
   add_foreign_key "chapters", "bibles", on_delete: :restrict
   add_foreign_key "chapters", "books", on_delete: :restrict
   add_foreign_key "exposition_alternative_interpretations", "exposition_contents", on_delete: :cascade
+  add_foreign_key "exposition_analyses", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_contents", "sections", on_delete: :restrict
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_020042) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_020938) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -86,6 +86,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_020042) do
     t.index ["reflections"], name: "index_exposition_contents_on_reflections", using: :gin
     t.index ["section_id"], name: "index_exposition_contents_on_section_id"
     t.index ["tags"], name: "index_exposition_contents_on_tags", using: :gin
+  end
+
+  create_table "exposition_cross_references", force: :cascade do |t|
+    t.bigint "exposition_content_id", null: false
+    t.string "reference", null: false
+    t.string "note", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exposition_content_id"], name: "index_exposition_cross_references_on_exposition_content_id"
   end
 
   create_table "footnotes", force: :cascade do |t|
@@ -220,6 +229,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_020042) do
   add_foreign_key "exposition_alternative_interpretations", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_analyses", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_contents", "sections", on_delete: :restrict
+  add_foreign_key "exposition_cross_references", "exposition_contents", on_delete: :cascade
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict
   add_foreign_key "footnotes", "chapters", on_delete: :restrict


### PR DESCRIPTION
This pull request introduces a new `Exposition` module and adds several associated models, migrations, and schema updates to support the new functionality. The changes focus on creating a structured way to manage exposition content and its related entities.

### Changes

#### New Models and Associations:

* Added a new module `Exposition` with a `table_name_prefix` method to namespace the tables.
* Created the `Exposition::Content` model with associations to other exposition-related models and added validations and enums.
* Created the `Exposition::AlternativeInterpretation` model with associations and validations.
* Created the `Exposition::Analysis` model with associations and validations.
* Created the `Exposition::CrossReference` model with associations and validations.
* Created the `Exposition::Insight` model with associations, validations, and enums.
* Created the `Exposition::KeyTheme` model with associations and validations.
* Created the `Exposition::PersonalApplication` model with associations and validations.
* Added a `has_one` association to `exposition_content` with a dependent restriction.

#### Migrations:

* Added migration to create the `exposition_contents` table with necessary columns and indexes.
* Added migration to create the `exposition_alternative_interpretations` table.
* Added migration to create the `exposition_analyses` table.
* Added migration to create the `exposition_cross_references` table.
* Added migration to create the `exposition_insights` table.
* Added migration to create the `exposition_key_themes` table.
* Added migration to create the `exposition_personal_applications` table.

#### Schema Updates:

* Updated the schema to include the new `exposition_*` tables and their foreign keys.