### PR TITLE
Minor updates and improvements

### DIFF
--- a/app/models/exposition/analysis.rb
+++ b/app/models/exposition/analysis.rb
@@ -8,8 +8,8 @@
 # ---------------------------- | ------------------ | ---------------------------
 # **`id`**                     | `bigint`           | `not null, primary key`
 # **`note`**                   | `string`           | `not null`
+# **`part`**                   | `string`           | `not null`
 # **`position`**               | `integer`          | `not null`
-# **`section`**                | `string`           | `not null`
 # **`created_at`**             | `datetime`         | `not null`
 # **`updated_at`**             | `datetime`         | `not null`
 # **`exposition_content_id`**  | `bigint`           | `not null`
@@ -31,6 +31,6 @@ class Exposition::Analysis < ApplicationRecord
   # Validations
   validates :exposition_content, presence: true
   validates :note, presence: true
+  validates :part, presence: true
   validates :position, presence: true
-  validates :section, presence: true
 end

--- a/app/models/exposition/insight.rb
+++ b/app/models/exposition/insight.rb
@@ -33,5 +33,5 @@ class Exposition::Insight < ApplicationRecord
   validates :note, presence: true
 
   # Enums
-  enum :kind, { personal: "personal" }
+  enum :kind, { christ_centered: "christ_centered" }
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -45,7 +45,7 @@ class Section < ApplicationRecord
   belongs_to :heading
   has_many :section_segment_associations, dependent: :destroy
   has_many :segments, through: :section_segment_associations
-  has_one :exposition_content, dependent: :restrict_with_error
+  has_one :exposition_content, dependent: :restrict_with_error, class_name: "Exposition::Content"
 
   # Validations
   validates :bible, presence: true

--- a/db/migrate/20250329020042_create_exposition_analyses.rb
+++ b/db/migrate/20250329020042_create_exposition_analyses.rb
@@ -2,7 +2,7 @@ class CreateExpositionAnalyses < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_analyses do |t|
       t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
-      t.string :section, null: false
+      t.string :part, null: false
       t.string :note, null: false
       t.integer :position, null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,7 +60,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_022208) do
 
   create_table "exposition_analyses", force: :cascade do |t|
     t.bigint "exposition_content_id", null: false
-    t.string "section", null: false
+    t.string "part", null: false
     t.string "note", null: false
     t.integer "position", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Stuff I missed in https://github.com/thyword-study/scribe/pull/37.

### Changes

This pull request includes several changes to the `exposition` models and database schema. The most important changes involve renaming a field, updating validations, and modifying associations.

#### Changes to `exposition` models and schema:

* Renamed the `section` field to `part` and updated the corresponding validation. 
* Updated the migration to reflect the renaming of the `section` field to `part`.
* Updated the schema to reflect the renaming of the `section` field to `part`.

#### Changes to `exposition` insights:

* Changed the `kind` enum value from `personal` to `christ_centered`.

#### Changes to associations:

* Modified the `exposition_content` association to specify the class name `Exposition::Content`.