### PR TITLE
Improve sectioning of segments

### DIFF
--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -103,11 +103,7 @@ class Segment < ApplicationRecord
     # * `qa` - Poetry - Acrostic Heading/Marker
     # * `qr` - Poetry - Right Aligned
     segments.chunk_while do |previous_segment, next_segment|
-      if GROUPABLE_STYLES.include? next_segment.usx_style.to_sym
-        # If we have groupable styles following each other group them into the
-        # same section.
-        groupable = GROUPABLE_STYLES.include?(previous_segment.usx_style.to_sym) && GROUPABLE_STYLES.include?(next_segment.usx_style.to_sym)
-
+      if GROUPABLE_STYLES.include?(previous_segment.usx_style.to_sym) && GROUPABLE_STYLES.include?(next_segment.usx_style.to_sym)
         # For groupable styles such as list and poetry styles, if they are
         # following each other it makes sense to stylistically group them
         # following based on their levels.
@@ -118,7 +114,9 @@ class Segment < ApplicationRecord
         # contextually related.
         groupable_inscriptions = previous_segment.usx_style == "pc" && next_segment.usx_style == "pc"
 
-        (groupable && groupable_list) || (groupable && groupable_poetry) || (groupable && groupable_inscriptions)
+        # If we have groupable styles following each other group them into the
+        # same section.
+        groupable_list || groupable_poetry || groupable_inscriptions
       else
         false
       end

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -63,6 +63,7 @@ class Segment < ApplicationRecord
   HEADER_STYLES_INTRODUCTORY = [ "h", "toc2", "toc1", "mt1" ]
   HEADER_STYLES_SECTIONS_MAJOR = { ms: 0, ms1: 1, ms2: 2, ms3: 3, ms4: 4 }
   HEADER_STYLES_SECTIONS_MINOR = { s: 0, s1: 1, s2: 2, s3: 3, s4: 4 }
+  PARAGRAPH_STYLES = [ :m, :pmo ]
 
   # Groups a collection of segments into logically coherent sections for further
   # processing.
@@ -117,6 +118,12 @@ class Segment < ApplicationRecord
         # If we have groupable styles following each other group them into the
         # same section.
         groupable_list || groupable_poetry || groupable_inscriptions
+      elsif PARAGRAPH_STYLES.include?(previous_segment.usx_style.to_sym) && GROUPABLE_STYLES.include?(next_segment.usx_style.to_sym)
+        # Hanging paragraph segments without versese should be grouped with the
+        # following segment for a bit more context. Quite rare and so this
+        # should be considered special handling e.g. in Matthew 1 we have a
+        # "Next: (m)" section that is now handled by this.
+        !previous_segment.verses.exists?
       else
         false
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -142,20 +142,7 @@ metadata_content.xpath("/DBLMetadata/publications/publication/structure/content"
 
   # Chunk the segments into sections
   chapters = Chapter.where(bible: bible, book: book).order(number: :asc)
-  chapters.each do |chapter|
-    segments = Segment.where(bible: bible, book: book, chapter: chapter).where.not(usx_style: "b").order(usx_position: :asc)
-
-    segment_chunks = Segment.group_in_sections(segments)
-    segment_chunks.each.with_index(1) do |chunk_segments, chunk_position|
-      headings = chunk_segments.map { |segment| segment.heading }.uniq
-      raise RuntimeError, "Multiple heading not expected!" if headings.size != 1
-
-      heading = headings.first
-      section = Section.create!(bible: bible, book: book, chapter: chapter, heading: heading, position: chunk_position)
-      section.segments = chunk_segments
-      Rails.logger.info "Sectioned Bible Book ##{book.number}: [#{book.code}] #{book.title} Chapter ##{chapter.number} Header ##{heading.id} Section #{section.id} Segments #{section.segments.ids.join(",")}"
-    end
-  end
+  chapters.each { |chapter| chapter.group_segments_in_sections!(regroup: false) }
 end
 
 # Restore previous logger

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Chapter, type: :model do
+  describe '.group_segments_in_sections' do
+    it 'groups chapter segments in sections'
+  end
+end


### PR DESCRIPTION
As per the title.

### Changes

This pull request introduces significant enhancements to the chapter and segment models, focusing on grouping segments into sections and improving the handling of various segment styles. Additionally, it updates the seeding process and adds a pending test for the new functionality.

#### Enhancements to chapter and segment models:

* Added the `group_segments_in_sections!` method to organize chapter segments into logical sections, with support for regrouping if needed. This method includes detailed error handling and logging.
* Expanded the `GROUPABLE_STYLES` constant to include additional styles and introduced the `PARAGRAPH_STYLES` constant.
* Updated the `group_in_sections` method to handle new grouping logic for paragraphs, including special handling for hanging paragraphs.

#### Updates to seeding process:

* Simplified the seeding process by utilizing the new `group_segments_in_sections!` method from the `Chapter` model, ensuring consistency and reducing code duplication.

#### Testing:

* Added a basic RSpec test file for the `Chapter` model, including a placeholder test for the `group_segments_in_sections` method.