### PR TITLE
Remove seeding before tests

### DIFF
--- a/spec/factories/bibles.rb
+++ b/spec/factories/bibles.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :bible do
+    name { Faker::Lorem.word.titlecase }
+    code { (0...3).map { ('a'..'z').to_a.sample }.join.upcase }
+    rights_holder_name { Faker::Company.name }
+    rights_holder_url { Faker::Internet.url }
+    statement { Faker::Lorem.sentence }
+  end
+
+  factory :bible_bsb, parent: :bible do
+    name { "Berean Standard Bible" }
+    code { "BSB" }
+  end
+end

--- a/spec/factories/book.rb
+++ b/spec/factories/book.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :book do
+    title { Faker::Lorem.word.titlecase }
+    number { Faker::Number.between(from: 1, to: 66) }
+    code { (0...3).map { ('a'..'z').to_a.sample }.join.upcase }
+    slug { Faker::Internet.slug }
+    testament { [ "OT", "NT" ].sample }
+  end
+end

--- a/spec/factories/chapter.rb
+++ b/spec/factories/chapter.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :chapter do
+    number { Faker::Number.between(from: 1, to: 50) }
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe '#reference_path' do
-    let(:bible) { create(:bible, code: 'BSB') }
-    let(:book) { create(:book, bible: bible, code: 'GEN', slug: 'genesis') }
+    before(:example) do
+      bsb_bible = FactoryBot.create(:bible_bsb)
+      FactoryBot.create(:book, bible: bsb_bible, code: 'GEN', slug: 'genesis')
+    end
 
     it 'returns the correct path for a single verse reference' do
       expect(helper.reference_path(target: 'GEN 1:1')).to eq("/bibles/bsb/books/genesis/chapters/1#v1")

--- a/spec/requests/bibles_controller_spec.rb
+++ b/spec/requests/bibles_controller_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe BiblesController, type: :request do
   describe 'GET #show' do
     it 'returns the correct response' do
-      get bible_path code: 'bsb'
+      bible = FactoryBot.create(:bible)
+
+      get bible_path code: bible.code.downcase
 
       aggregate_failures do
         expect(response).to have_http_status(:temporary_redirect)

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe BooksController, type: :request do
   describe 'GET #index' do
     it 'returns the correct response' do
-      get bible_books_path bible_code: 'bsb'
+      bible = FactoryBot.create(:bible)
+
+      get bible_books_path bible_code: bible.code.downcase
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)
@@ -14,7 +16,10 @@ RSpec.describe BooksController, type: :request do
 
   describe 'GET #show' do
     it 'returns the correct response' do
-      get bible_book_path bible_code: 'bsb', slug: 'genesis'
+      bible = FactoryBot.create(:bible)
+      book = FactoryBot.create(:book, bible: bible)
+
+      get bible_book_path bible_code: bible.code.downcase, slug: book.slug
 
       aggregate_failures do
         expect(response).to have_http_status(:temporary_redirect)

--- a/spec/requests/chapters_controller_spec.rb
+++ b/spec/requests/chapters_controller_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe BooksController, type: :request do
   describe 'GET #index' do
     it 'returns the correct response' do
-      get bible_book_chapters_path bible_code: 'bsb', book_slug: "genesis"
+      bible = FactoryBot.create(:bible)
+      book = FactoryBot.create(:book, bible: bible)
+
+      get bible_book_chapters_path bible_code: bible.code.downcase, book_slug: book.slug
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)
@@ -14,7 +17,11 @@ RSpec.describe BooksController, type: :request do
 
   describe 'GET #show' do
     it 'returns the correct response' do
-      get bible_book_chapter_path bible_code: 'bsb', book_slug: 'genesis', number: "1"
+      bible = FactoryBot.create(:bible)
+      book = FactoryBot.create(:book, bible: bible)
+      chapter = FactoryBot.create(:chapter, bible: bible, book: book, number: 1)
+
+      get bible_book_chapter_path bible_code: bible.code.downcase, book_slug: book.slug, number: chapter.number
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe PagesController, type: :request do
   describe 'GET #home' do
     it 'returns the correct response' do
+      FactoryBot.create(:bible_bsb)
+
       get root_path
 
       aggregate_failures do

--- a/spec/support/database_cleaner_active_record.rb
+++ b/spec/support/database_cleaner_active_record.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.around do |example|
+  config.around(:each) do |example|
     DatabaseCleaner.cleaning do
       example.run
     end

--- a/spec/support/database_cleaner_active_record.rb
+++ b/spec/support/database_cleaner_active_record.rb
@@ -2,8 +2,6 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
-
-    Rails.application.load_seed
   end
 
   config.around do |example|


### PR DESCRIPTION
This pull request introduces several changes to the test factories and updates to the test cases to use these factories. The most important changes include the creation of new factories for `Bible`, `Book`, and `Chapter` models, and the refactoring of test cases to utilize these new factories.

### Changes

#### Creation of new factories:

* Added a factory for `Bible` and a specific factory for `Berean Standard Bible` (`bible_bsb`).
* Added a factory for `Book`.
* Added a factory for `Chapter`.

#### Refactoring test cases to use factories:

* Updated the test setup to use the `bible_bsb` factory for creating a `Bible` and `Book` instance.
* Refactored the test to create a `Bible` instance using the factory before making a request.
* Refactored tests to create `Bible` and `Book` instances using factories before making requests.
* Refactored tests to create `Bible`, `Book`, and `Chapter` instances using factories before making requests.
* Added the creation of a `bible_bsb` instance using the factory before making a request.

#### Other changes:

* Modified the `DatabaseCleaner` configuration to use `around(:each)` instead of `around`.