### PR TITLE
Configure test HTTP interaction recording and replay

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,4 +87,8 @@ group :test do
   # Strategies for cleaning databases using ActiveRecord. Can be used to ensure
   # a clean state for testing.
   gem "database_cleaner-active_record", "~> 2.1"
+
+  # Record your test suite's HTTP interactions and replay them during future
+  # test runs for fast, deterministic, accurate tests.
+  gem "vcr", "~> 6.3", ">= 6.3.1"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -91,4 +91,8 @@ group :test do
   # Record your test suite's HTTP interactions and replay them during future
   # test runs for fast, deterministic, accurate tests.
   gem "vcr", "~> 6.3", ">= 6.3.1"
+
+  # WebMock allows stubbing HTTP requests and setting expectations on HTTP
+  # requests.
+  gem "webmock", "~> 3.25", ">= 3.25.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     annotaterb (4.14.0)
     ast (2.4.2)
     base64 (0.2.0)
@@ -89,6 +91,9 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
     connection_pool (2.5.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
@@ -120,6 +125,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.1.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.1.0)
@@ -253,6 +259,7 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    rexml (3.4.1)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -360,6 +367,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
@@ -407,6 +418,7 @@ DEPENDENCIES
   validate_url (~> 1.0, >= 1.0.15)
   vcr (~> 6.3, >= 6.3.1)
   web-console
+  webmock (~> 3.25, >= 3.25.1)
 
 BUNDLED WITH
    2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,6 +353,8 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
+    vcr (6.3.1)
+      base64
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -403,6 +405,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   validate_url (~> 1.0, >= 1.0.15)
+  vcr (~> 6.3, >= 6.3.1)
   web-console
 
 BUNDLED WITH

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # return unless Rails.env.test?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'vcr'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'vcr'
+require 'webmock/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,4 @@
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/cassettes'
+  config.hook_into :webmock
+end


### PR DESCRIPTION
Enhances the test suite by adding new gems and configuring VCR for recording and replaying HTTP interactions. The most important changes include adding the `vcr` and `webmock` gems to the `Gemfile`, requiring these gems in the test setup, and configuring VCR.

### Changes

#### Enhancements to the test suite:

* Added the `vcr` and `webmock` gems to the `test` group to enable recording and replaying HTTP interactions.
* Required the `vcr` and `webmock/rspec` gems to be included in the test setup.
* Configured VCR to use `webmock` and set the cassette library directory to `spec/cassettes`.

### References

* **VCR**
   * https://github.com/vcr/vcr
   * https://benoittgt.github.io/vcr/
* **Webmock**
   * https://github.com/bblimke/webmock