### PR TITLE
Add Exposition prompt models

### DIFF
--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -4,23 +4,26 @@
 #
 # ### Columns
 #
-# Name                       | Type               | Attributes
-# -------------------------- | ------------------ | ---------------------------
-# **`id`**                   | `bigint`           | `not null, primary key`
-# **`context`**              | `text`             | `not null`
-# **`highlights`**           | `text`             | `default([]), not null, is an Array`
-# **`interpretation_type`**  | `string`           | `not null`
-# **`people`**               | `string`           | `default([]), not null, is an Array`
-# **`places`**               | `string`           | `default([]), not null, is an Array`
-# **`reflections`**          | `text`             | `default([]), not null, is an Array`
-# **`summary`**              | `text`             | `not null`
-# **`tags`**                 | `string`           | `default([]), not null, is an Array`
-# **`created_at`**           | `datetime`         | `not null`
-# **`updated_at`**           | `datetime`         | `not null`
-# **`section_id`**           | `bigint`           | `not null`
+# Name                             | Type               | Attributes
+# -------------------------------- | ------------------ | ---------------------------
+# **`id`**                         | `bigint`           | `not null, primary key`
+# **`context`**                    | `text`             | `not null`
+# **`highlights`**                 | `text`             | `default([]), not null, is an Array`
+# **`interpretation_type`**        | `string`           | `not null`
+# **`people`**                     | `string`           | `default([]), not null, is an Array`
+# **`places`**                     | `string`           | `default([]), not null, is an Array`
+# **`reflections`**                | `text`             | `default([]), not null, is an Array`
+# **`summary`**                    | `text`             | `not null`
+# **`tags`**                       | `string`           | `default([]), not null, is an Array`
+# **`created_at`**                 | `datetime`         | `not null`
+# **`updated_at`**                 | `datetime`         | `not null`
+# **`exposition_user_prompt_id`**  | `bigint`           | `not null`
+# **`section_id`**                 | `bigint`           | `not null`
 #
 # ### Indexes
 #
+# * `index_exposition_contents_on_exposition_user_prompt_id`:
+#     * **`exposition_user_prompt_id`**
 # * `index_exposition_contents_on_highlights` (_using_ gin):
 #     * **`highlights`**
 # * `index_exposition_contents_on_people` (_using_ gin):
@@ -37,11 +40,14 @@
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`exposition_user_prompt_id => exposition_user_prompts.id`**
+# * `fk_rails_...` (_ON DELETE => restrict_):
 #     * **`section_id => sections.id`**
 #
 class Exposition::Content < ApplicationRecord
   # Associations
   belongs_to :section
+  belongs_to :exposition_user_prompt
   has_many :exposition_alternative_interpretations, dependent: :destroy
   has_many :exposition_analyses, dependent: :destroy
   has_many :exposition_cross_references, dependent: :destroy

--- a/app/models/exposition/system_prompt.rb
+++ b/app/models/exposition/system_prompt.rb
@@ -12,6 +12,9 @@
 # **`updated_at`**  | `datetime`         | `not null`
 #
 class Exposition::SystemPrompt < ApplicationRecord
+  # Associations
+  has_many :exposition_user_prompts, dependent: :restrict_with_error
+
   # Validations
   validates :content, presence: true
 end

--- a/app/models/exposition/system_prompt.rb
+++ b/app/models/exposition/system_prompt.rb
@@ -1,0 +1,17 @@
+# ## Schema Information
+#
+# Table name: `exposition_system_prompts`
+#
+# ### Columns
+#
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`content`**     | `text`             | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+#
+class Exposition::SystemPrompt < ApplicationRecord
+  # Validations
+  validates :content, presence: true
+end

--- a/app/models/exposition/user_prompt.rb
+++ b/app/models/exposition/user_prompt.rb
@@ -1,0 +1,32 @@
+# ## Schema Information
+#
+# Table name: `exposition_user_prompts`
+#
+# ### Columns
+#
+# Name                               | Type               | Attributes
+# ---------------------------------- | ------------------ | ---------------------------
+# **`id`**                           | `bigint`           | `not null, primary key`
+# **`content`**                      | `text`             | `not null`
+# **`created_at`**                   | `datetime`         | `not null`
+# **`updated_at`**                   | `datetime`         | `not null`
+# **`exposition_system_prompt_id`**  | `bigint`           |
+#
+# ### Indexes
+#
+# * `index_exposition_user_prompts_on_exposition_system_prompt_id`:
+#     * **`exposition_system_prompt_id`**
+#
+# ### Foreign Keys
+#
+# * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`exposition_system_prompt_id => exposition_system_prompts.id`**
+#
+class Exposition::UserPrompt < ApplicationRecord
+  # Associations
+  belongs_to :exposition_system_prompt
+
+  # Validations
+  validates :content, presence: true
+  validates :exposition_system_prompt, presence: true
+end

--- a/app/models/exposition/user_prompt.rb
+++ b/app/models/exposition/user_prompt.rb
@@ -25,6 +25,7 @@
 class Exposition::UserPrompt < ApplicationRecord
   # Associations
   belongs_to :exposition_system_prompt
+  has_one :exposition_content, dependent: :restrict_with_error
 
   # Validations
   validates :content, presence: true

--- a/db/migrate/20250401011118_create_exposition_system_prompts.rb
+++ b/db/migrate/20250401011118_create_exposition_system_prompts.rb
@@ -1,0 +1,9 @@
+class CreateExpositionSystemPrompts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_system_prompts do |t|
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250401025836_create_exposition_user_prompts.rb
+++ b/db/migrate/20250401025836_create_exposition_user_prompts.rb
@@ -1,0 +1,10 @@
+class CreateExpositionUserPrompts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :exposition_user_prompts do |t|
+      t.references :exposition_system_prompt, foreign_key: { on_delete: :restrict }
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250401040656_add_exposition_user_prompt_to_exposition_contents.rb
+++ b/db/migrate/20250401040656_add_exposition_user_prompt_to_exposition_contents.rb
@@ -1,0 +1,5 @@
+class AddExpositionUserPromptToExpositionContents < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :exposition_contents, :exposition_user_prompt, null: false, foreign_key: { on_delete: :restrict }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_01_025836) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -80,6 +80,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_025836) do
     t.string "tags", default: [], null: false, array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "exposition_user_prompt_id", null: false
+    t.index ["exposition_user_prompt_id"], name: "index_exposition_contents_on_exposition_user_prompt_id"
     t.index ["highlights"], name: "index_exposition_contents_on_highlights", using: :gin
     t.index ["people"], name: "index_exposition_contents_on_people", using: :gin
     t.index ["places"], name: "index_exposition_contents_on_places", using: :gin
@@ -269,6 +271,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_025836) do
   add_foreign_key "chapters", "books", on_delete: :restrict
   add_foreign_key "exposition_alternative_interpretations", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_analyses", "exposition_contents", on_delete: :cascade
+  add_foreign_key "exposition_contents", "exposition_user_prompts", on_delete: :restrict
   add_foreign_key "exposition_contents", "sections", on_delete: :restrict
   add_foreign_key "exposition_cross_references", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_insights", "exposition_contents", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_01_011118) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_01_025836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -128,6 +128,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_011118) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "exposition_user_prompts", force: :cascade do |t|
+    t.bigint "exposition_system_prompt_id"
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["exposition_system_prompt_id"], name: "index_exposition_user_prompts_on_exposition_system_prompt_id"
   end
 
   create_table "footnotes", force: :cascade do |t|
@@ -266,6 +274,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_011118) do
   add_foreign_key "exposition_insights", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_key_themes", "exposition_contents", on_delete: :cascade
   add_foreign_key "exposition_personal_applications", "exposition_contents", on_delete: :cascade
+  add_foreign_key "exposition_user_prompts", "exposition_system_prompts", on_delete: :restrict
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict
   add_foreign_key "footnotes", "chapters", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_022208) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_01_011118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -122,6 +122,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_022208) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["exposition_content_id"], name: "idx_on_exposition_content_id_b900e2aa68"
+  end
+
+  create_table "exposition_system_prompts", force: :cascade do |t|
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "footnotes", force: :cascade do |t|

--- a/spec/factories/exposition/system_prompts.rb
+++ b/spec/factories/exposition/system_prompts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :exposition_system_prompt, class: 'Exposition::SystemPrompt' do
+    content { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 100) }
+  end
+end

--- a/spec/factories/exposition/user_prompts.rb
+++ b/spec/factories/exposition/user_prompts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :exposition_user_prompt, class: 'Exposition::UserPrompt' do
+    content { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 10) }
+  end
+end


### PR DESCRIPTION
Introduces several changes to the `exposition` module, focusing on adding new prompt model and their corresponding database migrations, associations, and validations.

### Changes

The most important changes include the addition of `Exposition::SystemPrompt` and `Exposition::UserPrompt` models, updates to the `Exposition::Content` model, and the necessary database migrations to support these changes.

#### New Models and Associations:

* Added the `Exposition::SystemPrompt` model with associations and validations.
* Added the `Exposition::UserPrompt` model with associations and validations.

#### Updates to Existing Models:

* Updated the `Exposition::Content` model to include a new association with `Exposition::UserPrompt` and added the corresponding foreign key.

#### Database Migrations:

* Created the `exposition_system_prompts` table.
* Created the `exposition_user_prompts` table with a foreign key to `exposition_system_prompts`.
* Added a reference to `exposition_user_prompt` in the `exposition_contents` table.

#### Schema Updates:

* Updated the schema to reflect the new tables and foreign keys.