### PR TITLE
Improve configuration of exposition models

### DIFF
--- a/app/models/exposition/alternative_interpretation.rb
+++ b/app/models/exposition/alternative_interpretation.rb
@@ -4,24 +4,24 @@
 #
 # ### Columns
 #
-# Name                         | Type               | Attributes
-# ---------------------------- | ------------------ | ---------------------------
-# **`id`**                     | `bigint`           | `not null, primary key`
-# **`note`**                   | `text`             | `not null`
-# **`title`**                  | `string`           | `not null`
-# **`created_at`**             | `datetime`         | `not null`
-# **`updated_at`**             | `datetime`         | `not null`
-# **`exposition_content_id`**  | `bigint`           | `not null`
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`note`**        | `text`             | `not null`
+# **`title`**       | `string`           | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`content_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
-# * `idx_on_exposition_content_id_705a740ad5`:
-#     * **`exposition_content_id`**
+# * `index_exposition_alternative_interpretations_on_content_id`:
+#     * **`content_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => cascade_):
-#     * **`exposition_content_id => exposition_contents.id`**
+#     * **`content_id => exposition_contents.id`**
 #
 class Exposition::AlternativeInterpretation < ApplicationRecord
   # Associations

--- a/app/models/exposition/alternative_interpretation.rb
+++ b/app/models/exposition/alternative_interpretation.rb
@@ -25,10 +25,10 @@
 #
 class Exposition::AlternativeInterpretation < ApplicationRecord
   # Associations
-  belongs_to :exposition_content
+  belongs_to :content
 
   # Validations
-  validates :exposition_content, presence: true
+  validates :content, presence: true
   validates :note, presence: true
   validates :title, presence: true
 end

--- a/app/models/exposition/analysis.rb
+++ b/app/models/exposition/analysis.rb
@@ -4,25 +4,25 @@
 #
 # ### Columns
 #
-# Name                         | Type               | Attributes
-# ---------------------------- | ------------------ | ---------------------------
-# **`id`**                     | `bigint`           | `not null, primary key`
-# **`note`**                   | `text`             | `not null`
-# **`part`**                   | `string`           | `not null`
-# **`position`**               | `integer`          | `not null`
-# **`created_at`**             | `datetime`         | `not null`
-# **`updated_at`**             | `datetime`         | `not null`
-# **`exposition_content_id`**  | `bigint`           | `not null`
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`note`**        | `text`             | `not null`
+# **`part`**        | `string`           | `not null`
+# **`position`**    | `integer`          | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`content_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
-# * `index_exposition_analyses_on_exposition_content_id`:
-#     * **`exposition_content_id`**
+# * `index_exposition_analyses_on_content_id`:
+#     * **`content_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => cascade_):
-#     * **`exposition_content_id => exposition_contents.id`**
+#     * **`content_id => exposition_contents.id`**
 #
 class Exposition::Analysis < ApplicationRecord
   # Associations

--- a/app/models/exposition/analysis.rb
+++ b/app/models/exposition/analysis.rb
@@ -8,7 +8,7 @@
 # ----------------- | ------------------ | ---------------------------
 # **`id`**          | `bigint`           | `not null, primary key`
 # **`note`**        | `text`             | `not null`
-# **`part`**        | `string`           | `not null`
+# **`part`**        | `text`             | `not null`
 # **`position`**    | `integer`          | `not null`
 # **`created_at`**  | `datetime`         | `not null`
 # **`updated_at`**  | `datetime`         | `not null`

--- a/app/models/exposition/analysis.rb
+++ b/app/models/exposition/analysis.rb
@@ -26,10 +26,10 @@
 #
 class Exposition::Analysis < ApplicationRecord
   # Associations
-  belongs_to :exposition_content
+  belongs_to :content
 
   # Validations
-  validates :exposition_content, presence: true
+  validates :content, presence: true
   validates :note, presence: true
   validates :part, presence: true
   validates :position, presence: true

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -47,13 +47,13 @@
 class Exposition::Content < ApplicationRecord
   # Associations
   belongs_to :section
-  belongs_to :exposition_user_prompt
-  has_many :exposition_alternative_interpretations, dependent: :destroy
-  has_many :exposition_analyses, dependent: :destroy
-  has_many :exposition_cross_references, dependent: :destroy
-  has_many :exposition_insights, dependent: :destroy
-  has_many :exposition_key_themes, dependent: :destroy
-  has_many :exposition_personal_applications, dependent: :destroy
+  belongs_to :user_prompt
+  has_many :alternative_interpretations, dependent: :destroy
+  has_many :analyses, dependent: :destroy
+  has_many :cross_references, dependent: :destroy
+  has_many :insights, dependent: :destroy
+  has_many :key_themes, dependent: :destroy
+  has_many :personal_applications, dependent: :destroy
 
   # Validations
   validates :context, presence: true
@@ -63,6 +63,7 @@ class Exposition::Content < ApplicationRecord
   validates :section, presence: true
   validates :summary, presence: true
   validates :tags, presence: true
+  validates :user_prompt, presence: true
 
   # Enums
   enum :interpretation_type, { majority: "majority", minority:  "minority" }

--- a/app/models/exposition/content.rb
+++ b/app/models/exposition/content.rb
@@ -4,26 +4,24 @@
 #
 # ### Columns
 #
-# Name                             | Type               | Attributes
-# -------------------------------- | ------------------ | ---------------------------
-# **`id`**                         | `bigint`           | `not null, primary key`
-# **`context`**                    | `text`             | `not null`
-# **`highlights`**                 | `text`             | `default([]), not null, is an Array`
-# **`interpretation_type`**        | `string`           | `not null`
-# **`people`**                     | `string`           | `default([]), not null, is an Array`
-# **`places`**                     | `string`           | `default([]), not null, is an Array`
-# **`reflections`**                | `text`             | `default([]), not null, is an Array`
-# **`summary`**                    | `text`             | `not null`
-# **`tags`**                       | `string`           | `default([]), not null, is an Array`
-# **`created_at`**                 | `datetime`         | `not null`
-# **`updated_at`**                 | `datetime`         | `not null`
-# **`exposition_user_prompt_id`**  | `bigint`           | `not null`
-# **`section_id`**                 | `bigint`           | `not null`
+# Name                       | Type               | Attributes
+# -------------------------- | ------------------ | ---------------------------
+# **`id`**                   | `bigint`           | `not null, primary key`
+# **`context`**              | `text`             | `not null`
+# **`highlights`**           | `text`             | `default([]), not null, is an Array`
+# **`interpretation_type`**  | `string`           | `not null`
+# **`people`**               | `string`           | `default([]), not null, is an Array`
+# **`places`**               | `string`           | `default([]), not null, is an Array`
+# **`reflections`**          | `text`             | `default([]), not null, is an Array`
+# **`summary`**              | `text`             | `not null`
+# **`tags`**                 | `string`           | `default([]), not null, is an Array`
+# **`created_at`**           | `datetime`         | `not null`
+# **`updated_at`**           | `datetime`         | `not null`
+# **`section_id`**           | `bigint`           | `not null`
+# **`user_prompt_id`**       | `bigint`           | `not null`
 #
 # ### Indexes
 #
-# * `index_exposition_contents_on_exposition_user_prompt_id`:
-#     * **`exposition_user_prompt_id`**
 # * `index_exposition_contents_on_highlights` (_using_ gin):
 #     * **`highlights`**
 # * `index_exposition_contents_on_people` (_using_ gin):
@@ -36,13 +34,15 @@
 #     * **`section_id`**
 # * `index_exposition_contents_on_tags` (_using_ gin):
 #     * **`tags`**
+# * `index_exposition_contents_on_user_prompt_id`:
+#     * **`user_prompt_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => restrict_):
-#     * **`exposition_user_prompt_id => exposition_user_prompts.id`**
-# * `fk_rails_...` (_ON DELETE => restrict_):
 #     * **`section_id => sections.id`**
+# * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`user_prompt_id => exposition_user_prompts.id`**
 #
 class Exposition::Content < ApplicationRecord
   # Associations

--- a/app/models/exposition/cross_reference.rb
+++ b/app/models/exposition/cross_reference.rb
@@ -4,24 +4,24 @@
 #
 # ### Columns
 #
-# Name                         | Type               | Attributes
-# ---------------------------- | ------------------ | ---------------------------
-# **`id`**                     | `bigint`           | `not null, primary key`
-# **`note`**                   | `text`             | `not null`
-# **`reference`**              | `string`           | `not null`
-# **`created_at`**             | `datetime`         | `not null`
-# **`updated_at`**             | `datetime`         | `not null`
-# **`exposition_content_id`**  | `bigint`           | `not null`
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`note`**        | `text`             | `not null`
+# **`reference`**   | `string`           | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`content_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
-# * `index_exposition_cross_references_on_exposition_content_id`:
-#     * **`exposition_content_id`**
+# * `index_exposition_cross_references_on_content_id`:
+#     * **`content_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => cascade_):
-#     * **`exposition_content_id => exposition_contents.id`**
+#     * **`content_id => exposition_contents.id`**
 #
 class Exposition::CrossReference < ApplicationRecord
   # Associations

--- a/app/models/exposition/cross_reference.rb
+++ b/app/models/exposition/cross_reference.rb
@@ -25,10 +25,10 @@
 #
 class Exposition::CrossReference < ApplicationRecord
   # Associations
-  belongs_to :exposition_content
+  belongs_to :content
 
   # Validations
-  validates :exposition_content, presence: true
+  validates :content, presence: true
   validates :note, presence: true
   validates :reference, presence: true
 end

--- a/app/models/exposition/insight.rb
+++ b/app/models/exposition/insight.rb
@@ -4,24 +4,24 @@
 #
 # ### Columns
 #
-# Name                         | Type               | Attributes
-# ---------------------------- | ------------------ | ---------------------------
-# **`id`**                     | `bigint`           | `not null, primary key`
-# **`kind`**                   | `string`           | `not null`
-# **`note`**                   | `text`             | `not null`
-# **`created_at`**             | `datetime`         | `not null`
-# **`updated_at`**             | `datetime`         | `not null`
-# **`exposition_content_id`**  | `bigint`           | `not null`
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`kind`**        | `string`           | `not null`
+# **`note`**        | `text`             | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`content_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
-# * `index_exposition_insights_on_exposition_content_id`:
-#     * **`exposition_content_id`**
+# * `index_exposition_insights_on_content_id`:
+#     * **`content_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => cascade_):
-#     * **`exposition_content_id => exposition_contents.id`**
+#     * **`content_id => exposition_contents.id`**
 #
 class Exposition::Insight < ApplicationRecord
   # Associations

--- a/app/models/exposition/insight.rb
+++ b/app/models/exposition/insight.rb
@@ -25,10 +25,10 @@
 #
 class Exposition::Insight < ApplicationRecord
   # Associations
-  belongs_to :exposition_content
+  belongs_to :content
 
   # Validations
-  validates :exposition_content, presence: true
+  validates :content, presence: true
   validates :kind, presence: true
   validates :note, presence: true
 

--- a/app/models/exposition/key_theme.rb
+++ b/app/models/exposition/key_theme.rb
@@ -4,24 +4,24 @@
 #
 # ### Columns
 #
-# Name                         | Type               | Attributes
-# ---------------------------- | ------------------ | ---------------------------
-# **`id`**                     | `bigint`           | `not null, primary key`
-# **`description`**            | `text`             | `not null`
-# **`theme`**                  | `string`           | `not null`
-# **`created_at`**             | `datetime`         | `not null`
-# **`updated_at`**             | `datetime`         | `not null`
-# **`exposition_content_id`**  | `bigint`           | `not null`
+# Name               | Type               | Attributes
+# ------------------ | ------------------ | ---------------------------
+# **`id`**           | `bigint`           | `not null, primary key`
+# **`description`**  | `text`             | `not null`
+# **`theme`**        | `string`           | `not null`
+# **`created_at`**   | `datetime`         | `not null`
+# **`updated_at`**   | `datetime`         | `not null`
+# **`content_id`**   | `bigint`           | `not null`
 #
 # ### Indexes
 #
-# * `index_exposition_key_themes_on_exposition_content_id`:
-#     * **`exposition_content_id`**
+# * `index_exposition_key_themes_on_content_id`:
+#     * **`content_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => cascade_):
-#     * **`exposition_content_id => exposition_contents.id`**
+#     * **`content_id => exposition_contents.id`**
 #
 class Exposition::KeyTheme < ApplicationRecord
   # Associations

--- a/app/models/exposition/key_theme.rb
+++ b/app/models/exposition/key_theme.rb
@@ -25,10 +25,10 @@
 #
 class Exposition::KeyTheme < ApplicationRecord
   # Associations
-  belongs_to :exposition_content
+  belongs_to :content
 
   # Validations
+  validates :content, presence: true
   validates :description, presence: true
-  validates :exposition_content, presence: true
   validates :theme, presence: true
 end

--- a/app/models/exposition/personal_application.rb
+++ b/app/models/exposition/personal_application.rb
@@ -25,10 +25,10 @@
 #
 class Exposition::PersonalApplication < ApplicationRecord
   # Associations
-  belongs_to :exposition_content
+  belongs_to :content
 
   # Validations
-  validates :exposition_content, presence: true
+  validates :content, presence: true
   validates :note, presence: true
   validates :title, presence: true
 end

--- a/app/models/exposition/personal_application.rb
+++ b/app/models/exposition/personal_application.rb
@@ -4,24 +4,24 @@
 #
 # ### Columns
 #
-# Name                         | Type               | Attributes
-# ---------------------------- | ------------------ | ---------------------------
-# **`id`**                     | `bigint`           | `not null, primary key`
-# **`note`**                   | `text`             | `not null`
-# **`title`**                  | `string`           | `not null`
-# **`created_at`**             | `datetime`         | `not null`
-# **`updated_at`**             | `datetime`         | `not null`
-# **`exposition_content_id`**  | `bigint`           | `not null`
+# Name              | Type               | Attributes
+# ----------------- | ------------------ | ---------------------------
+# **`id`**          | `bigint`           | `not null, primary key`
+# **`note`**        | `text`             | `not null`
+# **`title`**       | `string`           | `not null`
+# **`created_at`**  | `datetime`         | `not null`
+# **`updated_at`**  | `datetime`         | `not null`
+# **`content_id`**  | `bigint`           | `not null`
 #
 # ### Indexes
 #
-# * `idx_on_exposition_content_id_b900e2aa68`:
-#     * **`exposition_content_id`**
+# * `index_exposition_personal_applications_on_content_id`:
+#     * **`content_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => cascade_):
-#     * **`exposition_content_id => exposition_contents.id`**
+#     * **`content_id => exposition_contents.id`**
 #
 class Exposition::PersonalApplication < ApplicationRecord
   # Associations

--- a/app/models/exposition/system_prompt.rb
+++ b/app/models/exposition/system_prompt.rb
@@ -7,7 +7,7 @@
 # Name              | Type               | Attributes
 # ----------------- | ------------------ | ---------------------------
 # **`id`**          | `bigint`           | `not null, primary key`
-# **`content`**     | `text`             | `not null`
+# **`text`**        | `text`             | `not null`
 # **`created_at`**  | `datetime`         | `not null`
 # **`updated_at`**  | `datetime`         | `not null`
 #
@@ -16,5 +16,5 @@ class Exposition::SystemPrompt < ApplicationRecord
   has_many :user_prompts, dependent: :restrict_with_error
 
   # Validations
-  validates :content, presence: true
+  validates :text, presence: true
 end

--- a/app/models/exposition/system_prompt.rb
+++ b/app/models/exposition/system_prompt.rb
@@ -13,7 +13,7 @@
 #
 class Exposition::SystemPrompt < ApplicationRecord
   # Associations
-  has_many :exposition_user_prompts, dependent: :restrict_with_error
+  has_many :user_prompts, dependent: :restrict_with_error
 
   # Validations
   validates :content, presence: true

--- a/app/models/exposition/user_prompt.rb
+++ b/app/models/exposition/user_prompt.rb
@@ -4,23 +4,23 @@
 #
 # ### Columns
 #
-# Name                               | Type               | Attributes
-# ---------------------------------- | ------------------ | ---------------------------
-# **`id`**                           | `bigint`           | `not null, primary key`
-# **`content`**                      | `text`             | `not null`
-# **`created_at`**                   | `datetime`         | `not null`
-# **`updated_at`**                   | `datetime`         | `not null`
-# **`exposition_system_prompt_id`**  | `bigint`           |
+# Name                    | Type               | Attributes
+# ----------------------- | ------------------ | ---------------------------
+# **`id`**                | `bigint`           | `not null, primary key`
+# **`content`**           | `text`             | `not null`
+# **`created_at`**        | `datetime`         | `not null`
+# **`updated_at`**        | `datetime`         | `not null`
+# **`system_prompt_id`**  | `bigint`           |
 #
 # ### Indexes
 #
-# * `index_exposition_user_prompts_on_exposition_system_prompt_id`:
-#     * **`exposition_system_prompt_id`**
+# * `index_exposition_user_prompts_on_system_prompt_id`:
+#     * **`system_prompt_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => restrict_):
-#     * **`exposition_system_prompt_id => exposition_system_prompts.id`**
+#     * **`system_prompt_id => exposition_system_prompts.id`**
 #
 class Exposition::UserPrompt < ApplicationRecord
   # Associations

--- a/app/models/exposition/user_prompt.rb
+++ b/app/models/exposition/user_prompt.rb
@@ -24,10 +24,10 @@
 #
 class Exposition::UserPrompt < ApplicationRecord
   # Associations
-  belongs_to :exposition_system_prompt
-  has_one :exposition_content, dependent: :restrict_with_error
+  belongs_to :system_prompt
+  has_one :content, dependent: :restrict_with_error
 
   # Validations
   validates :content, presence: true
-  validates :exposition_system_prompt, presence: true
+  validates :system_prompt, presence: true
 end

--- a/app/models/exposition/user_prompt.rb
+++ b/app/models/exposition/user_prompt.rb
@@ -10,24 +10,31 @@
 # **`content`**           | `text`             | `not null`
 # **`created_at`**        | `datetime`         | `not null`
 # **`updated_at`**        | `datetime`         | `not null`
+# **`section_id`**        | `bigint`           | `not null`
 # **`system_prompt_id`**  | `bigint`           |
 #
 # ### Indexes
 #
+# * `index_exposition_user_prompts_on_section_id`:
+#     * **`section_id`**
 # * `index_exposition_user_prompts_on_system_prompt_id`:
 #     * **`system_prompt_id`**
 #
 # ### Foreign Keys
 #
 # * `fk_rails_...` (_ON DELETE => restrict_):
+#     * **`section_id => sections.id`**
+# * `fk_rails_...` (_ON DELETE => restrict_):
 #     * **`system_prompt_id => exposition_system_prompts.id`**
 #
 class Exposition::UserPrompt < ApplicationRecord
   # Associations
+  belongs_to :section
   belongs_to :system_prompt
   has_one :content, dependent: :restrict_with_error
 
   # Validations
   validates :content, presence: true
+  validates :section, presence: true
   validates :system_prompt, presence: true
 end

--- a/app/models/exposition/user_prompt.rb
+++ b/app/models/exposition/user_prompt.rb
@@ -7,7 +7,7 @@
 # Name                    | Type               | Attributes
 # ----------------------- | ------------------ | ---------------------------
 # **`id`**                | `bigint`           | `not null, primary key`
-# **`content`**           | `text`             | `not null`
+# **`text`**              | `text`             | `not null`
 # **`created_at`**        | `datetime`         | `not null`
 # **`updated_at`**        | `datetime`         | `not null`
 # **`section_id`**        | `bigint`           | `not null`
@@ -34,7 +34,7 @@ class Exposition::UserPrompt < ApplicationRecord
   has_one :content, dependent: :restrict_with_error
 
   # Validations
-  validates :content, presence: true
   validates :section, presence: true
   validates :system_prompt, presence: true
+  validates :text, presence: true
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -45,6 +45,7 @@ class Section < ApplicationRecord
   belongs_to :heading
   has_many :section_segment_associations, dependent: :destroy
   has_many :segments, through: :section_segment_associations
+  has_many :exposition_user_prompts, dependent: :restrict_with_error, class_name: "Exposition::UserPrompt"
   has_one :exposition_content, dependent: :restrict_with_error, class_name: "Exposition::Content"
 
   # Validations

--- a/db/migrate/20250329015205_create_exposition_alternative_interpretations.rb
+++ b/db/migrate/20250329015205_create_exposition_alternative_interpretations.rb
@@ -1,7 +1,7 @@
 class CreateExpositionAlternativeInterpretations < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_alternative_interpretations do |t|
-      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.references :content, null: false, foreign_key: { on_delete: :cascade, to_table: :exposition_contents }
       t.string :title, null: false
       t.text :note, null: false
 

--- a/db/migrate/20250329020042_create_exposition_analyses.rb
+++ b/db/migrate/20250329020042_create_exposition_analyses.rb
@@ -1,7 +1,7 @@
 class CreateExpositionAnalyses < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_analyses do |t|
-      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.references :content, null: false, foreign_key: { on_delete: :cascade, to_table: :exposition_contents }
       t.text :part, null: false
       t.text :note, null: false
       t.integer :position, null: false

--- a/db/migrate/20250329020938_create_exposition_cross_references.rb
+++ b/db/migrate/20250329020938_create_exposition_cross_references.rb
@@ -1,7 +1,7 @@
 class CreateExpositionCrossReferences < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_cross_references do |t|
-      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.references :content, null: false, foreign_key: { on_delete: :cascade, to_table: :exposition_contents }
       t.string :reference, null: false
       t.text :note, null: false
 

--- a/db/migrate/20250329021421_create_exposition_insights.rb
+++ b/db/migrate/20250329021421_create_exposition_insights.rb
@@ -1,7 +1,7 @@
 class CreateExpositionInsights < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_insights do |t|
-      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.references :content, null: false, foreign_key: { on_delete: :cascade, to_table: :exposition_contents }
       t.string :kind, null: false
       t.text :note, null: false
 

--- a/db/migrate/20250329021817_create_exposition_key_themes.rb
+++ b/db/migrate/20250329021817_create_exposition_key_themes.rb
@@ -1,7 +1,7 @@
 class CreateExpositionKeyThemes < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_key_themes do |t|
-      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.references :content, null: false, foreign_key: { on_delete: :cascade, to_table: :exposition_contents }
       t.string :theme, null: false
       t.text :description, null: false
 

--- a/db/migrate/20250329022208_create_exposition_personal_applications.rb
+++ b/db/migrate/20250329022208_create_exposition_personal_applications.rb
@@ -1,7 +1,7 @@
 class CreateExpositionPersonalApplications < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_personal_applications do |t|
-      t.references :exposition_content, null: false, foreign_key: { on_delete: :cascade }
+      t.references :content, null: false, foreign_key: { on_delete: :cascade, to_table: :exposition_contents }
       t.string :title, null: false
       t.text :note, null: false
 

--- a/db/migrate/20250401011118_create_exposition_system_prompts.rb
+++ b/db/migrate/20250401011118_create_exposition_system_prompts.rb
@@ -1,7 +1,7 @@
 class CreateExpositionSystemPrompts < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_system_prompts do |t|
-      t.text :content, null: false
+      t.text :text, null: false
 
       t.timestamps
     end

--- a/db/migrate/20250401025836_create_exposition_user_prompts.rb
+++ b/db/migrate/20250401025836_create_exposition_user_prompts.rb
@@ -3,7 +3,7 @@ class CreateExpositionUserPrompts < ActiveRecord::Migration[8.0]
     create_table :exposition_user_prompts do |t|
       t.references :system_prompt, foreign_key: { on_delete: :restrict, to_table: :exposition_system_prompts }
       t.references :section, null: false, foreign_key: { on_delete: :restrict }
-      t.text :content, null: false
+      t.text :text, null: false
 
       t.timestamps
     end

--- a/db/migrate/20250401025836_create_exposition_user_prompts.rb
+++ b/db/migrate/20250401025836_create_exposition_user_prompts.rb
@@ -2,6 +2,7 @@ class CreateExpositionUserPrompts < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_user_prompts do |t|
       t.references :system_prompt, foreign_key: { on_delete: :restrict, to_table: :exposition_system_prompts }
+      t.references :section, null: false, foreign_key: { on_delete: :restrict }
       t.text :content, null: false
 
       t.timestamps

--- a/db/migrate/20250401025836_create_exposition_user_prompts.rb
+++ b/db/migrate/20250401025836_create_exposition_user_prompts.rb
@@ -1,7 +1,7 @@
 class CreateExpositionUserPrompts < ActiveRecord::Migration[8.0]
   def change
     create_table :exposition_user_prompts do |t|
-      t.references :exposition_system_prompt, foreign_key: { on_delete: :restrict }
+      t.references :system_prompt, foreign_key: { on_delete: :restrict, to_table: :exposition_system_prompts }
       t.text :content, null: false
 
       t.timestamps

--- a/db/migrate/20250401040656_add_exposition_user_prompt_to_exposition_contents.rb
+++ b/db/migrate/20250401040656_add_exposition_user_prompt_to_exposition_contents.rb
@@ -1,5 +1,5 @@
 class AddExpositionUserPromptToExpositionContents < ActiveRecord::Migration[8.0]
   def change
-    add_reference :exposition_contents, :exposition_user_prompt, null: false, foreign_key: { on_delete: :restrict }
+    add_reference :exposition_contents, :user_prompt, null: false, foreign_key: { on_delete: :restrict, to_table: :exposition_user_prompts }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,22 +50,22 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
   end
 
   create_table "exposition_alternative_interpretations", force: :cascade do |t|
-    t.bigint "exposition_content_id", null: false
+    t.bigint "content_id", null: false
     t.string "title", null: false
     t.text "note", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["exposition_content_id"], name: "idx_on_exposition_content_id_705a740ad5"
+    t.index ["content_id"], name: "index_exposition_alternative_interpretations_on_content_id"
   end
 
   create_table "exposition_analyses", force: :cascade do |t|
-    t.bigint "exposition_content_id", null: false
+    t.bigint "content_id", null: false
     t.string "part", null: false
     t.text "note", null: false
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["exposition_content_id"], name: "index_exposition_analyses_on_exposition_content_id"
+    t.index ["content_id"], name: "index_exposition_analyses_on_content_id"
   end
 
   create_table "exposition_contents", force: :cascade do |t|
@@ -80,50 +80,50 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
     t.string "tags", default: [], null: false, array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "exposition_user_prompt_id", null: false
-    t.index ["exposition_user_prompt_id"], name: "index_exposition_contents_on_exposition_user_prompt_id"
+    t.bigint "user_prompt_id", null: false
     t.index ["highlights"], name: "index_exposition_contents_on_highlights", using: :gin
     t.index ["people"], name: "index_exposition_contents_on_people", using: :gin
     t.index ["places"], name: "index_exposition_contents_on_places", using: :gin
     t.index ["reflections"], name: "index_exposition_contents_on_reflections", using: :gin
     t.index ["section_id"], name: "index_exposition_contents_on_section_id"
     t.index ["tags"], name: "index_exposition_contents_on_tags", using: :gin
+    t.index ["user_prompt_id"], name: "index_exposition_contents_on_user_prompt_id"
   end
 
   create_table "exposition_cross_references", force: :cascade do |t|
-    t.bigint "exposition_content_id", null: false
+    t.bigint "content_id", null: false
     t.string "reference", null: false
     t.text "note", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["exposition_content_id"], name: "index_exposition_cross_references_on_exposition_content_id"
+    t.index ["content_id"], name: "index_exposition_cross_references_on_content_id"
   end
 
   create_table "exposition_insights", force: :cascade do |t|
-    t.bigint "exposition_content_id", null: false
+    t.bigint "content_id", null: false
     t.string "kind", null: false
     t.text "note", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["exposition_content_id"], name: "index_exposition_insights_on_exposition_content_id"
+    t.index ["content_id"], name: "index_exposition_insights_on_content_id"
   end
 
   create_table "exposition_key_themes", force: :cascade do |t|
-    t.bigint "exposition_content_id", null: false
+    t.bigint "content_id", null: false
     t.string "theme", null: false
     t.text "description", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["exposition_content_id"], name: "index_exposition_key_themes_on_exposition_content_id"
+    t.index ["content_id"], name: "index_exposition_key_themes_on_content_id"
   end
 
   create_table "exposition_personal_applications", force: :cascade do |t|
-    t.bigint "exposition_content_id", null: false
+    t.bigint "content_id", null: false
     t.string "title", null: false
     t.text "note", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["exposition_content_id"], name: "idx_on_exposition_content_id_b900e2aa68"
+    t.index ["content_id"], name: "index_exposition_personal_applications_on_content_id"
   end
 
   create_table "exposition_system_prompts", force: :cascade do |t|
@@ -133,11 +133,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
   end
 
   create_table "exposition_user_prompts", force: :cascade do |t|
-    t.bigint "exposition_system_prompt_id"
+    t.bigint "system_prompt_id"
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["exposition_system_prompt_id"], name: "index_exposition_user_prompts_on_exposition_system_prompt_id"
+    t.index ["system_prompt_id"], name: "index_exposition_user_prompts_on_system_prompt_id"
   end
 
   create_table "footnotes", force: :cascade do |t|
@@ -269,15 +269,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
   add_foreign_key "books", "bibles", on_delete: :restrict
   add_foreign_key "chapters", "bibles", on_delete: :restrict
   add_foreign_key "chapters", "books", on_delete: :restrict
-  add_foreign_key "exposition_alternative_interpretations", "exposition_contents", on_delete: :cascade
-  add_foreign_key "exposition_analyses", "exposition_contents", on_delete: :cascade
-  add_foreign_key "exposition_contents", "exposition_user_prompts", on_delete: :restrict
+  add_foreign_key "exposition_alternative_interpretations", "exposition_contents", column: "content_id", on_delete: :cascade
+  add_foreign_key "exposition_analyses", "exposition_contents", column: "content_id", on_delete: :cascade
+  add_foreign_key "exposition_contents", "exposition_user_prompts", column: "user_prompt_id", on_delete: :restrict
   add_foreign_key "exposition_contents", "sections", on_delete: :restrict
-  add_foreign_key "exposition_cross_references", "exposition_contents", on_delete: :cascade
-  add_foreign_key "exposition_insights", "exposition_contents", on_delete: :cascade
-  add_foreign_key "exposition_key_themes", "exposition_contents", on_delete: :cascade
-  add_foreign_key "exposition_personal_applications", "exposition_contents", on_delete: :cascade
-  add_foreign_key "exposition_user_prompts", "exposition_system_prompts", on_delete: :restrict
+  add_foreign_key "exposition_cross_references", "exposition_contents", column: "content_id", on_delete: :cascade
+  add_foreign_key "exposition_insights", "exposition_contents", column: "content_id", on_delete: :cascade
+  add_foreign_key "exposition_key_themes", "exposition_contents", column: "content_id", on_delete: :cascade
+  add_foreign_key "exposition_personal_applications", "exposition_contents", column: "content_id", on_delete: :cascade
+  add_foreign_key "exposition_user_prompts", "exposition_system_prompts", column: "system_prompt_id", on_delete: :restrict
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict
   add_foreign_key "footnotes", "chapters", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,7 +60,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
 
   create_table "exposition_analyses", force: :cascade do |t|
     t.bigint "content_id", null: false
-    t.string "part", null: false
+    t.text "part", null: false
     t.text "note", null: false
     t.integer "position", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,7 +127,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
   end
 
   create_table "exposition_system_prompts", force: :cascade do |t|
-    t.text "content", null: false
+    t.text "text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -135,7 +135,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
   create_table "exposition_user_prompts", force: :cascade do |t|
     t.bigint "system_prompt_id"
     t.bigint "section_id", null: false
-    t.text "content", null: false
+    t.text "text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["section_id"], name: "index_exposition_user_prompts_on_section_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -134,9 +134,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
 
   create_table "exposition_user_prompts", force: :cascade do |t|
     t.bigint "system_prompt_id"
+    t.bigint "section_id", null: false
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["section_id"], name: "index_exposition_user_prompts_on_section_id"
     t.index ["system_prompt_id"], name: "index_exposition_user_prompts_on_system_prompt_id"
   end
 
@@ -278,6 +280,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_01_040656) do
   add_foreign_key "exposition_key_themes", "exposition_contents", column: "content_id", on_delete: :cascade
   add_foreign_key "exposition_personal_applications", "exposition_contents", column: "content_id", on_delete: :cascade
   add_foreign_key "exposition_user_prompts", "exposition_system_prompts", column: "system_prompt_id", on_delete: :restrict
+  add_foreign_key "exposition_user_prompts", "sections", on_delete: :restrict
   add_foreign_key "footnotes", "bibles", on_delete: :restrict
   add_foreign_key "footnotes", "books", on_delete: :restrict
   add_foreign_key "footnotes", "chapters", on_delete: :restrict

--- a/spec/factories/exposition/system_prompts.rb
+++ b/spec/factories/exposition/system_prompts.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :exposition_system_prompt, class: 'Exposition::SystemPrompt' do
-    content { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 100) }
+    text { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 100) }
   end
 end

--- a/spec/factories/exposition/user_prompts.rb
+++ b/spec/factories/exposition/user_prompts.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :exposition_user_prompt, class: 'Exposition::UserPrompt' do
-    content { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 10) }
+    text { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 10) }
   end
 end


### PR DESCRIPTION
Simplifies and standardises naming across the `exposition` models and their migrations. See commits for details.