### PR TITLE
Rename the `bibles` resource path to `translations`

### DIFF
--- a/app/controllers/bibles_controller.rb
+++ b/app/controllers/bibles_controller.rb
@@ -1,8 +1,0 @@
-class BiblesController < ApplicationController
-  def show
-    translation_code = params[:code].to_s.strip.upcase
-    translation = Bible::Translation.find_by! code: translation_code
-
-    redirect_to bible_books_url(bible_code: translation.code.downcase), status: :temporary_redirect
-  end
-end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,18 +1,18 @@
 class BooksController < ApplicationController
   def index
-    translation_code = params[:bible_code].to_s.strip.upcase
+    translation_code = params[:translation_code].to_s.strip.upcase
 
     @translation = Bible::Translation.find_by! code: translation_code
     @books = @translation.books.order(number: :asc)
   end
 
   def show
-    translation_code = params[:bible_code].to_s.strip.upcase
+    translation_code = params[:translation_code].to_s.strip.upcase
     book_slug = params[:slug].to_s.strip
 
     @translation = Bible::Translation.find_by! code: translation_code
     @book = Bible::Book.find_by! translation: @translation, slug: book_slug
 
-    redirect_to bible_book_chapters_url(bible_code: @translation.code.downcase, book_slug: @book.slug), status: :temporary_redirect
+    redirect_to translation_book_chapters_url(translation_code: @translation.code.downcase, book_slug: @book.slug), status: :temporary_redirect
   end
 end

--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,6 +1,6 @@
 class ChaptersController < ApplicationController
   def index
-    translation_code = params[:bible_code].to_s.strip.upcase
+    translation_code = params[:translation_code].to_s.strip.upcase
     book_slug = params[:book_slug].to_s.strip
 
     @translation = Bible::Translation.find_by! code: translation_code
@@ -9,7 +9,7 @@ class ChaptersController < ApplicationController
   end
 
   def show
-    translation_code = params[:bible_code].to_s.strip.upcase
+    translation_code = params[:translation_code].to_s.strip.upcase
     book_slug = params[:book_slug].to_s.strip
     chapter_number = params[:number].to_s.strip
 

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -1,0 +1,8 @@
+class TranslationsController < ApplicationController
+  def show
+    translation_code = params[:code].to_s.strip.upcase
+    translation = Bible::Translation.find_by! code: translation_code
+
+    redirect_to translation_books_url(translation_code: translation.code.downcase), status: :temporary_redirect
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,9 +12,9 @@ module ApplicationHelper
       verse_number = parsed_target[:verses][0]
       verse_number = verse_number[0] if verse_number.kind_of?(Array)
 
-      bible_book_chapter_path(bible_code: translation.code.downcase, book_slug: book.slug, number: chapter_number, anchor: "v#{verse_number}")
+      translation_book_chapter_path(translation_code: translation.code.downcase, book_slug: book.slug, number: chapter_number, anchor: "v#{verse_number}")
     else
-      bible_book_chapter_path(bible_code: translation.code.downcase, book_slug: book.slug, number: chapter_number)
+      translation_book_chapter_path(translation_code: translation.code.downcase, book_slug: book.slug, number: chapter_number)
     end
   end
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -21,7 +21,7 @@
     <ul class="mt-6 list-none">
       <% @books.old_testament.each do |book| %> 
         <li class="mt-2 text-xl">
-          <%= link_to book.title, bible_book_path(bible_code: @translation.code.downcase, slug: book.slug), class: "text-blue-600 hover:text-blue-800" %>
+          <%= link_to book.title, translation_book_path(translation_code: @translation.code.downcase, slug: book.slug), class: "text-blue-600 hover:text-blue-800" %>
         </li>
       <% end %>
     </ul>
@@ -32,7 +32,7 @@
     <ul class="mt-6 list-none">
       <% @books.new_testament.each do |book| %> 
         <li class="mt-2 text-xl">
-          <%= link_to book.title, bible_book_path(bible_code: @translation.code.downcase, slug: book.slug), class: "text-blue-600 hover:text-blue-800" %>
+          <%= link_to book.title, translation_book_path(translation_code: @translation.code.downcase, slug: book.slug), class: "text-blue-600 hover:text-blue-800" %>
         </li>
       <% end %>
     </ul>

--- a/app/views/chapters/index.html.erb
+++ b/app/views/chapters/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <nav class="mb-4 flex justify-center items-center">
-  <%= link_to bible_books_path(bible_code: @translation.code.downcase), class: "text-gray-400 hover:text-gray-500 flex flex-col items-center" do %>
+  <%= link_to translation_books_path(translation_code: @translation.code.downcase), class: "text-gray-400 hover:text-gray-500 flex flex-col items-center" do %>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 18.75 7.5-7.5 7.5 7.5" />
       <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 7.5-7.5 7.5 7.5" />
@@ -21,7 +21,7 @@
     <ul class="mt-6 list-none">
       <% @book.headings.major.where(level: 0).each do |heading| %>
         <li class="mt-3 text-xl">
-          <%= link_to heading.title, bible_book_chapter_path(bible_code: @translation.code.downcase, book_slug: @book.slug, number: heading.chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
+          <%= link_to heading.title, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: heading.chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
         </li>
       <% end %>
     </ul>
@@ -34,7 +34,7 @@
       <% @chapters.each do |chapter| %> 
         <li>
           <h3 class="mt-8 text-2xl font-semibold text-pretty text-gray-900">
-            <%= link_to "Chapter #{chapter.number}", bible_book_chapter_path(bible_code: @translation.code.downcase, book_slug: @book.slug, number: chapter.number), class: "text-blue-600 hover:text-blue-800" %>
+            <%= link_to "Chapter #{chapter.number}", translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: chapter.number), class: "text-blue-600 hover:text-blue-800" %>
           </h3>
 
           <ul class="mt-4 mb-2 list-none">
@@ -42,11 +42,11 @@
               <% case heading.level -%>
               <% when 1 %>
                 <li class="mt-2 text-xl">
-                  <%= link_to heading.title, bible_book_chapter_path(bible_code: @translation.code.downcase, book_slug: @book.slug, number: chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
+                  <%= link_to heading.title, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
                 </li>
               <% when 2 %>
                 <li class="mt-1 text-base italic">
-                  <%= link_to heading.title, bible_book_chapter_path(bible_code: @translation.code.downcase, book_slug: @book.slug, number: chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
+                  <%= link_to heading.title, translation_book_chapter_path(translation_code: @translation.code.downcase, book_slug: @book.slug, number: chapter.number, anchor: heading.title.parameterize), class: "text-blue-600 hover:text-blue-800" %>
                 </li>
               <% end %>
             <% end %>

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -19,7 +19,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6 shrink-0 text-gray-400">
           <path fill-rule="evenodd" d="M16.28 11.47a.75.75 0 0 1 0 1.06l-7.5 7.5a.75.75 0 0 1-1.06-1.06L14.69 12 7.72 5.03a.75.75 0 0 1 1.06-1.06l7.5 7.5Z" clip-rule="evenodd" />
         </svg>
-        <%= link_to @translation.code, bible_path(code: @translation.code.downcase), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" %>
+        <%= link_to @translation.code, translation_path(code: @translation.code.downcase), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" %>
       </div>
     </li>
     <li>
@@ -27,7 +27,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6 shrink-0 text-gray-400">
           <path fill-rule="evenodd" d="M16.28 11.47a.75.75 0 0 1 0 1.06l-7.5 7.5a.75.75 0 0 1-1.06-1.06L14.69 12 7.72 5.03a.75.75 0 0 1 1.06-1.06l7.5 7.5Z" clip-rule="evenodd" />
         </svg>
-        <%= link_to "Books", bible_books_path(bible_code: @translation.code.downcase), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" %>
+        <%= link_to "Books", translation_books_path(translation_code: @translation.code.downcase), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" %>
       </div>
     </li>
     <li>
@@ -35,14 +35,14 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6 shrink-0 text-gray-400">
           <path fill-rule="evenodd" d="M16.28 11.47a.75.75 0 0 1 0 1.06l-7.5 7.5a.75.75 0 0 1-1.06-1.06L14.69 12 7.72 5.03a.75.75 0 0 1 1.06-1.06l7.5 7.5Z" clip-rule="evenodd" />
         </svg>
-        <%= link_to "Chapters", bible_book_chapters_path(bible_code: @translation.code.downcase, book_slug: @book.slug), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" %>
+        <%= link_to "Chapters", translation_book_chapters_path(translation_code: @translation.code.downcase, book_slug: @book.slug), class: "ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" %>
       </div>
     </li>
   </ol>
 </nav>
 
 <main>
-  <%= link_to  bible_book_path(bible_code: @translation.code.downcase, slug: @book.slug), class: "text-blue-600 hover:text-blue-800" do %>
+  <%= link_to  translation_book_path(translation_code: @translation.code.downcase, slug: @book.slug), class: "text-blue-600 hover:text-blue-800" do %>
     <h1 class="text-4xl font-semibold text-pretty sm:text-5xl"><%= @book.title %></h1>
   <% end %>
 

--- a/app/views/commentary/chapters/show.html.erb
+++ b/app/views/commentary/chapters/show.html.erb
@@ -51,7 +51,7 @@
 
     <% @sections.each do |section| %>
       <%= tag.div id: "section-#{section.id}" do %>
-        <% if (Segment::CONTENT_STYLES & section.segments.pluck(:usx_style).map(&:to_sym)).any? %>
+        <% if section.expositable? %>
           <div class="overflow-hidden rounded-lg bg-gray-100 font-medium">
             <div class="px-4 py-5 sm:p-6">
               <%= render partial: "section", locals: { section: section }  %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -11,7 +11,7 @@
           God’s Word is always within reach. Read the Bible seamlessly or go deeper with verse-by-verse commentary for clearer understanding.
         </p>
         <div class="mt-8 flex items-center justify-center gap-x-4">
-          <%= link_to  bible_path(code: @translation.code.downcase), class: "rounded-md bg-blue-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600" do %>  
+          <%= link_to  translation_path(code: @translation.code.downcase), class: "rounded-md bg-blue-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600" do %>  
             <%= "Read the #{@translation.code} Bible" %>
           <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   resources :articles, param: :slug, only: [ :index, :show ]
 
   # Bible (Reading)
-  resources :bibles, param: :code, only: [ :show ], constraints: { code: /[a-z]+/ } do
+  resources :translations, param: :code, only: [ :show ], constraints: { code: /[a-z]+/ } do
     resources :books, param: :slug, only: [ :index, :show ] do
       resources :chapters, param: :number, only: [ :index, :show ] do
         resources :verses, param: :numbers, only: [ :index, :show ]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it 'returns the correct path for a single verse reference' do
-      expect(helper.reference_path(target: 'GEN 1:1')).to eq("/bibles/bsb/books/genesis/chapters/1#v1")
+      expect(helper.reference_path(target: 'GEN 1:1')).to eq("/translations/bsb/books/genesis/chapters/1#v1")
     end
 
     it 'returns the correct path for a chapter reference' do
-      expect(helper.reference_path(target: 'GEN 1')).to eq("/bibles/bsb/books/genesis/chapters/1")
+      expect(helper.reference_path(target: 'GEN 1')).to eq("/translations/bsb/books/genesis/chapters/1")
     end
 
     it 'returns the correct path for a range of verses' do
-      expect(helper.reference_path(target: 'GEN 1:1-5')).to eq("/bibles/bsb/books/genesis/chapters/1#v1")
+      expect(helper.reference_path(target: 'GEN 1:1-5')).to eq("/translations/bsb/books/genesis/chapters/1#v1")
     end
   end
 end

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BooksController, type: :request do
     it 'returns the correct response' do
       translation = FactoryBot.create(:translation)
 
-      get bible_books_path bible_code: translation.code.downcase
+      get translation_books_path translation_code: translation.code.downcase
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)
@@ -19,7 +19,7 @@ RSpec.describe BooksController, type: :request do
       translation = FactoryBot.create(:translation)
       book = FactoryBot.create(:translation_book, translation: translation)
 
-      get bible_book_path bible_code: translation.code.downcase, slug: book.slug
+      get translation_book_path translation_code: translation.code.downcase, slug: book.slug
 
       aggregate_failures do
         expect(response).to have_http_status(:temporary_redirect)

--- a/spec/requests/chapters_controller_spec.rb
+++ b/spec/requests/chapters_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ChaptersController, type: :request do
       translation = FactoryBot.create(:translation)
       book = FactoryBot.create(:translation_book, translation: translation)
 
-      get bible_book_chapters_path bible_code: translation.code.downcase, book_slug: book.slug
+      get translation_book_chapters_path translation_code: translation.code.downcase, book_slug: book.slug
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)
@@ -21,7 +21,7 @@ RSpec.describe ChaptersController, type: :request do
       book = FactoryBot.create(:translation_book, translation: translation)
       chapter = FactoryBot.create(:translation_chapter, translation: translation, book: book, number: 1)
 
-      get bible_book_chapter_path bible_code: translation.code.downcase, book_slug: book.slug, number: chapter.number
+      get translation_book_chapter_path translation_code: translation.code.downcase, book_slug: book.slug, number: chapter.number
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)

--- a/spec/requests/translations_controller_spec.rb
+++ b/spec/requests/translations_controller_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe BiblesController, type: :request do
+RSpec.describe TranslationsController, type: :request do
   describe 'GET #show' do
     it 'returns the correct response' do
       translation = FactoryBot.create(:translation)
 
-      get bible_path code: translation.code.downcase
+      get translation_path code: translation.code.downcase
 
       aggregate_failures do
         expect(response).to have_http_status(:temporary_redirect)

--- a/spec/requests/verses_controller_spec.rb
+++ b/spec/requests/verses_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe VersesController, type: :request do
   describe 'GET #index' do
     it 'returns the correct response' do
-      get bible_book_chapter_verses_path bible_code: 'bsb', book_slug: "genesis", chapter_number: "1"
+      get translation_book_chapter_verses_path translation_code: 'bsb', book_slug: "genesis", chapter_number: "1"
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)
@@ -15,7 +15,7 @@ RSpec.describe VersesController, type: :request do
   describe 'GET #show' do
     context "when it's one verse" do
       it 'returns the correct response' do
-        get bible_book_chapter_verse_path bible_code: 'bsb', book_slug: 'genesis', chapter_number: "1", numbers: "1"
+        get translation_book_chapter_verse_path translation_code: 'bsb', book_slug: 'genesis', chapter_number: "1", numbers: "1"
 
         aggregate_failures do
           expect(response).to have_http_status(:ok)
@@ -26,7 +26,7 @@ RSpec.describe VersesController, type: :request do
 
     context "when it's a range of verses" do
       it 'returns the correct response' do
-        get bible_book_chapter_verse_path bible_code: 'bsb', book_slug: 'genesis', chapter_number: "1", numbers: "1-5"
+        get translation_book_chapter_verse_path translation_code: 'bsb', book_slug: 'genesis', chapter_number: "1", numbers: "1-5"
 
         aggregate_failures do
           expect(response).to have_http_status(:ok)
@@ -37,7 +37,7 @@ RSpec.describe VersesController, type: :request do
 
     context "when it's multiple separate verses" do
       it 'returns the correct response' do
-        get bible_book_chapter_verse_path bible_code: 'bsb', book_slug: 'genesis', chapter_number: "1", numbers: "1,3,5"
+        get translation_book_chapter_verse_path translation_code: 'bsb', book_slug: 'genesis', chapter_number: "1", numbers: "1,3,5"
 
         aggregate_failures do
           expect(response).to have_http_status(:ok)

--- a/spec/routing/bibles_spec.rb
+++ b/spec/routing/bibles_spec.rb
@@ -1,9 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe BiblesController, type: :routing do
-  describe 'routing' do
-    it 'routes GET /bibles/:code to #show' do
-      expect(get: '/bibles/bsb').to route_to('bibles#show', code: 'bsb')
-    end
-  end
-end

--- a/spec/routing/books_spec.rb
+++ b/spec/routing/books_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe BooksController, type: :routing do
   describe 'routing' do
-    it 'routes GET /bibles/:bible_code/books to #index' do
-      expect(get: '/bibles/bsb/books').to route_to('books#index', bible_code: 'bsb')
+    it 'routes GET /translations/:translation_code/books to #index' do
+      expect(get: '/translations/bsb/books').to route_to('books#index', translation_code: 'bsb')
     end
 
-    it 'routes GET /bibles/:bible_code/books/:slug to #show' do
-      expect(get: '/bibles/bsb/books/genesis').to route_to('books#show', bible_code: 'bsb', slug: 'genesis')
+    it 'routes GET /translations/:translation_code/books/:slug to #show' do
+      expect(get: '/translations/bsb/books/genesis').to route_to('books#show', translation_code: 'bsb', slug: 'genesis')
     end
   end
 end

--- a/spec/routing/chapters_spec.rb
+++ b/spec/routing/chapters_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe ChaptersController, type: :routing do
   describe 'routing' do
-    it 'routes GET /bibles/:bible_code/books/:book_slug/chapters to #index' do
-      expect(get: '/bibles/bsb/books/genesis/chapters').to route_to('chapters#index', bible_code: 'bsb', book_slug: 'genesis')
+    it 'routes GET /translations/:translation_code/books/:book_slug/chapters to #index' do
+      expect(get: '/translations/bsb/books/genesis/chapters').to route_to('chapters#index', translation_code: 'bsb', book_slug: 'genesis')
     end
 
-    it 'routes GET /bibles/:bible_code/books/:book_slug/chapters/:number to #show' do
-      expect(get: '/bibles/bsb/books/genesis/chapters/1').to route_to('chapters#show', bible_code: 'bsb', book_slug: 'genesis', number: '1')
+    it 'routes GET /translations/:translation_code/books/:book_slug/chapters/:number to #show' do
+      expect(get: '/translations/bsb/books/genesis/chapters/1').to route_to('chapters#show', translation_code: 'bsb', book_slug: 'genesis', number: '1')
     end
   end
 end

--- a/spec/routing/translations_spec.rb
+++ b/spec/routing/translations_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe TranslationsController, type: :routing do
+  describe 'routing' do
+    it 'routes GET /translations/:code to #show' do
+      expect(get: '/translations/bsb').to route_to('translations#show', code: 'bsb')
+    end
+  end
+end

--- a/spec/routing/verses_spec.rb
+++ b/spec/routing/verses_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 RSpec.describe VersesController, type: :routing do
   describe 'routing' do
-    it 'routes GET /bibles/:bible_code/books/:book_slug/chapters/:chapter_number/verses to #index' do
-      expect(get: '/bibles/bsb/books/genesis/chapters/1/verses').to route_to('verses#index', bible_code: 'bsb', book_slug: 'genesis', chapter_number: '1')
+    it 'routes GET /translations/:translation_code/books/:book_slug/chapters/:chapter_number/verses to #index' do
+      expect(get: '/translations/bsb/books/genesis/chapters/1/verses').to route_to('verses#index', translation_code: 'bsb', book_slug: 'genesis', chapter_number: '1')
     end
 
-    it 'routes GET /bibles/:bible_code/books/:book_slug/chapters/:chapter_number/verses/:numbers to #show' do
+    it 'routes GET /translations/:translation_code/books/:book_slug/chapters/:chapter_number/verses/:numbers to #show' do
       aggregate_failures do
-        expect(get: '/bibles/bsb/books/genesis/chapters/1/verses/1').to route_to('verses#show', bible_code: 'bsb', book_slug: 'genesis', chapter_number: '1', numbers: '1')
-        expect(get: '/bibles/bsb/books/genesis/chapters/1/verses/1-5').to route_to('verses#show', bible_code: 'bsb', book_slug: 'genesis', chapter_number: '1', numbers: '1-5')
-        expect(get: '/bibles/bsb/books/genesis/chapters/1/verses/1,3,5').to route_to('verses#show', bible_code: 'bsb', book_slug: 'genesis', chapter_number: '1', numbers: '1,3,5')
+        expect(get: '/translations/bsb/books/genesis/chapters/1/verses/1').to route_to('verses#show', translation_code: 'bsb', book_slug: 'genesis', chapter_number: '1', numbers: '1')
+        expect(get: '/translations/bsb/books/genesis/chapters/1/verses/1-5').to route_to('verses#show', translation_code: 'bsb', book_slug: 'genesis', chapter_number: '1', numbers: '1-5')
+        expect(get: '/translations/bsb/books/genesis/chapters/1/verses/1,3,5').to route_to('verses#show', translation_code: 'bsb', book_slug: 'genesis', chapter_number: '1', numbers: '1,3,5')
       end
     end
   end


### PR DESCRIPTION
Rename the `bibles` resource to `translations` across the codebase to improve clarity and consistency. The changes include updates to controller names, route paths, view templates, helper methods, and test cases.

### Changes

#### Controller and Route Updates

* Renamed `BiblesController` to `TranslationsController` and updated the corresponding route paths.
* Updated routes in `config/routes.rb` to reflect the new resource name.

#### Parameter and Path Updates

* Changed parameter names from `bible_code` to `translation_code` in `BooksController`, `ChaptersController`, and associated views.
* Updated helper methods to use the new path names.

#### View Template Updates

* Modified view templates to use the new path helpers for `translation` resources.

#### Test Case Updates

* Updated test cases to reflect the new resource name and path changes.

#### Removal of Deprecated Files

* Removed the deprecated `spec/routing/bibles_spec.rb` file.