### PR TITLE
Remove `cssbundling-rails` (no longer needed)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,6 @@ gem "importmap-rails"
 gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
-# Bundle and process CSS [https://github.com/rails/cssbundling-rails]
-gem "cssbundling-rails"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,8 +95,6 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    cssbundling-rails (1.4.3)
-      railties (>= 6.0.0)
     database_cleaner-active_record (2.2.0)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
@@ -412,7 +410,6 @@ DEPENDENCIES
   bootsnap
   brakeman
   config (~> 5.5, >= 5.5.2)
-  cssbundling-rails
   database_cleaner-active_record (~> 2.1)
   debug
   factory_bot_rails (~> 6.2)


### PR DESCRIPTION
Removes the `cssbundling-rails` gem and related files/configuration from the app. I'm using [`tailwindcss-rails`](https://github.com/rails/tailwindcss-rails) for styling, which handles Tailwind integration natively and doesn't require a separate CSS bundler.