### PR TITLE
Add release Github Action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Version ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+  docker-gcr-release:
+    runs-on: ubuntu-latest
+    needs: github-release
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build, tag, and push image to GitHub Container Registry
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          labels: ${{ steps.metadata.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,20 +23,11 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     env:
       IMAGE: ghcr.io/${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare image metadata
         id: metadata
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Introduces a new GitHub Actions workflow for managing releases and simplifies the existing testing workflow by removing unnecessary steps and permissions. Below are the key changes:

### Changes

#### New Release Workflow

* Added a new GitHub Actions workflow `.github/workflows/release.yml` to automate the release process. This includes creating GitHub releases and publishing Docker images to the GitHub Container Registry.

#### Simplifications to Testing Workflow

* Removed unused permissions and the Docker login step from the `docker-build` job in `.github/workflows/test.yml`, as they are no longer required for the test workflow.