### PR TITLE
Replace `actions/create-release` with `softprops/action-gh-release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,21 @@ name: release
 on:
   push:
     tags:
-      - '*'
+      - '*.*.*'
 
 jobs:
   github-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Version ${{ github.ref }}
-          draft: false
-          prerelease: false
+          name: Version ${{ github.ref_name }}
+          generate_release_notes: true
 
   docker-gcr-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The most important changes include refining the tag matching pattern, adding permissions for the workflow, and switching to a different action for creating releases.

### Changes

#### Updates to Release Workflow

* Refined the tag matching pattern in the `push` trigger to match semantic versioning (`*.*.*`) instead of any tag (`*`). This ensures the workflow only runs for valid version tags.
* Added `contents: write` permissions for the `github-release` job, enabling the workflow to perform necessary actions like creating releases.
* Replaced the `actions/create-release@v1` action with `softprops/action-gh-release@v2` for the `Create Release` step, enabling automatic generation of release notes and simplifying configuration.

### Related

* https://github.com/thyword-study/scribe/pull/59